### PR TITLE
Fix Github link site footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -142,7 +142,7 @@ footer:
       # url:
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
-      url: github.com/pyOpenSci
+      url: https://github.com/pyOpenSci
     - label: "GitLab"
       icon: "fab fa-fw fa-gitlab"
       # url:


### PR DESCRIPTION
Seems that Jekyll is interpreting the `github.com` URL as a relative link.
Put an `https://` in there to try to fix this.