### PR TITLE
Add a package listing page to the website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -242,6 +242,11 @@ whitelist:
   - jemoji
   - jekyll-include-cache
 
+collections:
+  packages:
+    output: true
+    permalink: /:collection/:path/
+
 
 # Archives
 #  Type
@@ -283,6 +288,15 @@ compress_html:
 # Defaults
 defaults:
   # _posts
+  - scope:
+      path: ""
+      type: packages
+    values:
+      layout: single
+      author_profile: true
+      comments: # true
+      share: true
+      related: true
   - scope:
       path: ""
       type: posts

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -6,3 +6,5 @@ main:
 
   - title: "Resources"
     url: /resources/
+  - title: "Our Packages"
+    url: /python-packages/

--- a/_packages/nbless.md
+++ b/_packages/nbless.md
@@ -1,7 +1,7 @@
 ---
 package-name: Nbless
 maintainer: "Martin Skarzynski"
-description: "Construct, deconstruct, convert, execute, and prepare slides from Jupyter notebooks "
+description: "Construct, deconstruct, convert, execute, and prepare slides from Jupyter notebooks."
 image:
 github-link: http://www.github.com/
 ---

--- a/_packages/nbless.md
+++ b/_packages/nbless.md
@@ -1,0 +1,7 @@
+---
+package-name: Nbless
+maintainer: Martin
+description: "A package that does cool stuff..."
+image:
+github-link: http://www.github.com/
+---

--- a/_packages/nbless.md
+++ b/_packages/nbless.md
@@ -1,7 +1,7 @@
 ---
 package-name: Nbless
-maintainer: Martin
-description: "A package that does cool stuff..."
+maintainer: "Martin Skarzynski"
+description: "Construct, deconstruct, convert, execute, and prepare slides from Jupyter notebooks "
 image:
 github-link: http://www.github.com/
 ---

--- a/_pages/python-packages.md
+++ b/_pages/python-packages.md
@@ -45,7 +45,7 @@ as pyOpenSci packages!
   </a>
       </h2>
 
-      <p class="archive__item-excerpt" itemprop="description">Maintainer: {{ apackage.package-name }} {{ apackage.description }}Baz Boom design system including logo mark, website design, and branding applications.
+      <p class="archive__item-excerpt" itemprop="description">Maintainer: {{ apackage.package-name }} {{ apackage.description }}
   </p>
     </article>
   </div>

--- a/_pages/python-packages.md
+++ b/_pages/python-packages.md
@@ -2,7 +2,7 @@
 layout: single
 permalink: /python-packages/
 title: "pyOpenSci Accepted Packages and Under Review Packages"
-classes: wide
+classes:
 header:
     overlay_image: images/header.jpg
     overlay_filter: 0.6
@@ -11,9 +11,8 @@ header:
 
 ## PyOpenSci Accepted Packages
 The package below have already been through our review process and are accepted
-as pyOpenSci packages!
+as pyOpenSci packages.
 
-### Here is what a list would look like:
 <div>
 {% for apackage in site.packages %}
     <h2><a href="{{ apackage.github-link }}" target="_blank"> {{ apackage.package-name }} </a></h2>
@@ -22,36 +21,7 @@ as pyOpenSci packages!
 {% endfor %}
 </div>
 
-*********
-
-### AND here is what a grid could look like. this could look better as our list grows!!
-
-<div class="entries-grid">
-
-{% for apackage in site.packages %}
-  <div class="grid__item">
-    <article class="archive__item" itemscope="" itemtype="https://schema.org/CreativeWork">
-
-        <!-- do we really want images? it looks nicer that is for sure
-        i was thinking it would be nicer to have a grid that expands over time rather than a list but am option to options-->
-        <!--<div class="archive__item-teaser">
-          <img src="/minimal-mistakes/assets/images/unsplash-gallery-image-1-th.jpg" alt="">
-        </div>-->
-
-      <h2 class="archive__item-title" itemprop="headline">
-          <a href="{{ apackage.github-link }}" rel="permalink"> {{ apackage.package-name }}
-  </a>
-      </h2>
-
-      <p class="archive__item-excerpt" itemprop="description">Maintainer: {{ apackage.maintainer }} {{ apackage.description }}
-  </p>
-    </article>
-  </div>
-
-{% endfor %}
-
-</div>
-
-
 <br clear="both">
 ## PyOpenSci Packages In Review
+
+Check out our <a href="https://github.com/pyOpenSci/software-review/issues" target="_blank">Packages Current Under review in the issues portion of our software-review github repo to see our current community submissions.</a> Anyone is welcome to submit a package to pyopensci.

--- a/_pages/python-packages.md
+++ b/_pages/python-packages.md
@@ -1,0 +1,59 @@
+---
+layout: single
+permalink: /python-packages/
+title: "pyOpenSci Accepted Packages and Under Review Packages"
+classes: wide
+header:
+    overlay_image: images/header.jpg
+    overlay_filter: 0.6
+---
+
+
+## PyOpenSci Accepted Packages
+The package below have already been through our review process and are accepted
+as pyOpenSci packages!
+
+### Here is what a list would look like:
+<div>
+{% for apackage in site.packages %}
+    <h2><a href="{{ apackage.github-link }}" target="_blank"> {{ apackage.package-name }}  {{ apackage.maintainer }}</a></h2>
+  <p>{{ apackage.description | markdownify }}</p>
+{% endfor %}
+</div>
+
+*********
+
+### AND here is what a grid could look like. this could look better as our list grows!!
+
+<div class="entries-grid">
+
+{% for apackage in site.packages %}
+  <h2>{{ apackage.package-name }} - {{ apackage.maintainer }}</h2>
+  <p>{{ staff_member.content | markdownify }}</p>
+
+  <div class="grid__item">
+    <article class="archive__item" itemscope="" itemtype="https://schema.org/CreativeWork">
+
+        <!-- do we really want images? it looks nicer that is for sure
+        i was thinking it would be nicer to have a grid that expands over time rather than a list but am option to options-->
+        <!--<div class="archive__item-teaser">
+          <img src="/minimal-mistakes/assets/images/unsplash-gallery-image-1-th.jpg" alt="">
+        </div>-->
+
+      <h2 class="archive__item-title" itemprop="headline">
+          <a href="{{ apackage.github-link }}" rel="permalink"> {{ apackage.package-name }}
+  </a>
+      </h2>
+
+      <p class="archive__item-excerpt" itemprop="description">Maintainer: {{ apackage.package-name }} {{ apackage.description }}Baz Boom design system including logo mark, website design, and branding applications.
+  </p>
+    </article>
+  </div>
+
+{% endfor %}
+
+</div>
+
+
+<br clear="both">
+## PyOpenSci Packages In Review

--- a/_pages/python-packages.md
+++ b/_pages/python-packages.md
@@ -16,7 +16,8 @@ as pyOpenSci packages!
 ### Here is what a list would look like:
 <div>
 {% for apackage in site.packages %}
-    <h2><a href="{{ apackage.github-link }}" target="_blank"> {{ apackage.package-name }}  {{ apackage.maintainer }}</a></h2>
+    <h2><a href="{{ apackage.github-link }}" target="_blank"> {{ apackage.package-name }} </a></h2>
+     <p>MAINTAINER: {{ apackage.maintainer }}</p>
   <p>{{ apackage.description | markdownify }}</p>
 {% endfor %}
 </div>
@@ -28,9 +29,6 @@ as pyOpenSci packages!
 <div class="entries-grid">
 
 {% for apackage in site.packages %}
-  <h2>{{ apackage.package-name }} - {{ apackage.maintainer }}</h2>
-  <p>{{ staff_member.content | markdownify }}</p>
-
   <div class="grid__item">
     <article class="archive__item" itemscope="" itemtype="https://schema.org/CreativeWork">
 
@@ -45,7 +43,7 @@ as pyOpenSci packages!
   </a>
       </h2>
 
-      <p class="archive__item-excerpt" itemprop="description">Maintainer: {{ apackage.package-name }} {{ apackage.description }}
+      <p class="archive__item-excerpt" itemprop="description">Maintainer: {{ apackage.maintainer }} {{ apackage.description }}
   </p>
     </article>
   </div>


### PR DESCRIPTION
This PR would allow a package maintainer to add a package to the pyopensci website. We have a few options here. I created both a grid layout which will be nicer over time with more packages but ofcourse is more condensed and a regular listing. 

@marskar have a look at this please!! we could add an image for each package and it would nice BUT it would require the package owner to come up with an image. When a package is accepted however you could essentially add a md file [see this file](https://github.com/pyOpenSci/pyopensci.github.io/blob/add-packages/_packages/nbless.md) with a link to the github repo and a short description and list of maintainers and it would populate on the website. The image below shows both listing options and i was lazy about fully populating content for your package martin - just wanted to get the website working here  as a demo for friday's meeting!! :)

<img width="1024" alt="Screen Shot 2019-09-17 at 2 23 35 PM" src="https://user-images.githubusercontent.com/7649194/65076727-c3fc0880-d956-11e9-9720-74e66081f680.png">


All - any feedback is welcome here.