### PR TITLE
Add contributors yml file

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -7,6 +7,7 @@
     - leadership
     - Editor
     - package-maintainer
+  packages: [""]
 - name: Chris Holdgraf
   bio: 'Bio Here'
   organization: "Berkeley Bids, Project Jupyter, Binder"
@@ -16,3 +17,4 @@
     - leadership
     - Editor
     - package-maintainer
+  packages: [""]

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -9,7 +9,7 @@
     - package-maintainer
 - name: Chris Holdgraf
   bio: 'Bio Here'
-  organization: ""
+  organization: "Berkeley Bids, Project Jupyter, Binder"
   github_username: choldgraf
   github_image_id: 1839645
   contributor_type:

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -1,0 +1,18 @@
+- name: Leah Wasser
+  bio: 'Bio Here'
+  organization: "Earth Lab, University of Colorado - Boulder"
+  github_username: lwasser
+  github_image_id: 7649194 # You can find this by right clicking on the image in your bio, and copying the link. the last part contains a 7 digit number that is your avatar image!
+  contributor_type:
+    - leadership
+    - Editor
+    - package-maintainer
+- name: Chris Holdgraf
+  bio: 'Bio Here'
+  organization: ""
+  github_username: choldgraf
+  github_image_id: 1839645
+  contributor_type:
+    - leadership
+    - Editor
+    - package-maintainer

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,7 +3,8 @@ main:
 
   - title: "Get In Touch"
     url: /get-involved-contact/
-
+  - title: "Contributors"
+    url: /contributors/
   - title: "Resources"
     url: /resources/
   - title: "Our Packages"

--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -1,0 +1,8 @@
+- package-name: nbless
+  description: 'Construct, deconstruct, convert, execute, and prepare slides from Jupyter notebooks.'
+  maintainer: ["Martin Skarzynski"]
+  link: "https://github.com/py4ds/nbless"
+- package-name: pandera
+  description: 'Validate the types, properties, and statistics of pandas data structures'
+  maintainer: ["Niels Bantilan"]
+  link: "https://github.com/cosmicBboy/pandera"

--- a/_pages/contributors.md
+++ b/_pages/contributors.md
@@ -27,12 +27,13 @@ of today!
            <img src="https://avatars1.githubusercontent.com/u/{{ aperson.github_image_id }}?s=200&v=4" alt="">
          </div>
        {% endif %}
-     <h2 class="archive__item-title" itemprop="headline">
+     <h4 class="archive__item-title" itemprop="headline">
          <a href="https://www.github.com/{{ aperson.github_username }}" rel="permalink"> {{ aperson.name }}
  </a>
-     </h2>
-     <p class="archive__item-excerpt" itemprop="description"> {{ aperson.bio }}
- </p>
+     </h4>
+     <p class="contrib_org" itemprop="organization"> {{ aperson.organization }} </p>
+     <!--<p class="archive__item-excerpt" itemprop="description"> {{ aperson.bio }} </p>-->
+
    </article>
  </div>
 {% endfor %}

--- a/_pages/contributors.md
+++ b/_pages/contributors.md
@@ -1,0 +1,39 @@
+---
+layout: single
+permalink: /contributors/
+title: "pyOpenSci Contributors"
+classes:
+header:
+    overlay_image: images/header.jpg
+    overlay_filter: 0.6
+---
+
+## Who Is Involved with PyOpenSci?
+
+{{ site.data.contributors | size }} people have contributed to pyOpenSci as
+of today!
+
+
+## PyOpenSci Contributors
+
+<div class="entries-grid">
+{% for aperson in site.data.contributors %}
+ <div class="grid__item">
+   <article class="archive__item" itemscope="" itemtype="https://schema.org/CreativeWork">
+       <!-- do we really want images? it looks nicer that is for sure
+       i was thinking it would be nicer to have a grid that expands over time rather than a list but am option to options-->
+       {% if aperson.github_image_id %}
+         <div class="archive__item-teaser">
+           <img src="https://avatars1.githubusercontent.com/u/{{ aperson.github_image_id }}?s=200&v=4" alt="">
+         </div>
+       {% endif %}
+     <h2 class="archive__item-title" itemprop="headline">
+         <a href="https://www.github.com/{{ aperson.github_username }}" rel="permalink"> {{ aperson.name }}
+ </a>
+     </h2>
+     <p class="archive__item-excerpt" itemprop="description"> {{ aperson.bio }}
+ </p>
+   </article>
+ </div>
+{% endfor %}
+</div>

--- a/_pages/python-packages.md
+++ b/_pages/python-packages.md
@@ -20,9 +20,9 @@ The package below have already been through our review process and are accepted
 as pyOpenSci packages.
 
 <div>
-{% for apackage in site.packages %}
+{% for apackage in site.data.packages %}
     <h2><a href="{{ apackage.github-link }}" target="_blank"> {{ apackage.package-name }} </a></h2>
-     <p>MAINTAINER: {{ apackage.maintainer }}</p>
+     <p class="contrib_org">MAINTAINER: {{ apackage.maintainer }}</p>
   <p>{{ apackage.description | markdownify }}</p>
 {% endfor %}
 </div>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,0 +1,15 @@
+---
+# Only the main Sass file needs front matter (the dashes are enough)
+---
+
+body {font-size:90%}
+
+.contrib_org {font-weight:normal;
+  font-size:70%!important;
+  margin-bottom: 0!important;
+
+}
+
+@charset "utf-8";
+@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
+@import "minimal-mistakes"; // main partials


### PR DESCRIPTION
Hey @choldgraf and everyone... here is a start to a contributors page that is YAML based. it's a WIP but see what you think.  The awkward part is to get the gh image, i have to ask for it as i don't know of a good way to automate finding the image hash without a more complex CI process (which we could build if someone wanted to work on it. 

QUESTION: What contribution types do we want? that could be a separate yaml file potentially. 
<img width="1029" alt="Screen Shot 2019-10-10 at 1 33 06 PM" src="https://user-images.githubusercontent.com/7649194/66600322-8740bd00-eb62-11e9-80b5-2be761756bb6.png">


