### PR TITLE
updating language about joss and members

### DIFF
--- a/_pages/contributors.md
+++ b/_pages/contributors.md
@@ -10,11 +10,23 @@ header:
 
 ## Who Is Involved with PyOpenSci?
 
+pyOpenSci is a diverse community of people interested in building
+a community of practice around scientific software in Python.
+
 {{ site.data.contributors | size }} people have contributed to pyOpenSci as
 of today!
 
 
+## How can I contribute?
+
+There are many different ways to get involved with pyOpenSci! Contributions
+of all kinds are welcome - big and small, technical and non-technical.
+For a few ideas of how you can get involved, see [the 'get involved' section](home.html#Get-Involved)].
+
+
 ## PyOpenSci Contributors
+
+Below is a relatively up-to-date list of active contributors
 
 <div class="entries-grid">
 {% for aperson in site.data.contributors %}

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -78,7 +78,8 @@ We encourage our reviewers to provide more hands-on assistance and
 give more in-depth feedback than is typically required in JOSS. The goal
 of pyOpenSci is to ensure that all of its packages meet a minimum level
 of best practices and standards, and our review processes often take longer
-in order to help authors reach this bar.
+in order to help authors reach this bar. pyOpenSci also accepts some packages 
+that JOSS does not such as API wrappers to access data.
 
 pyOpenSci has a close relationship with JOSS, and we see these two communities
 as complementary of one another. **Any package that passes the pyOpenSci review and is [within scope](https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements) for JOSS

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -80,7 +80,7 @@ of best practices and standards, and our review processes often take longer
 in order to help authors reach this bar.
 
 pyOpenSci has a close relationship with JOSS, and we see these two communities
-as complementary of one another. **Any package that passes the pyOpenSci review
+as complementary of one another. **Any package that passes the pyOpenSci review and is [within scope](https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements) for JOSS
 process can be fast-tracked through the JOSS review process** (with the exception of a few
 JOSS-specific tasks you may need to perform). We hope that this encourages
 authors to submit to both JOSS and pyOpenSci.

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -22,30 +22,65 @@ scientific Python packages. We also build technical capacity by providing a
 curated repository of high-quality packages and enabling scientists to write
 and share their own software. We hope to foster a greater sense of community
 among scientific Python users so that we can help each other become better
-programmers and researchers.
+programmers and researchers. See our [list of Python packages](python-packages.html)
+for an idea of the open-source projects that pyOpenSci has assisted.
 
-pyOpenSci is being modeled after the successful [rOpenSci](https://ropensci.org/) community.  
+pyOpenSci is being modeled after the successful [rOpenSci](https://ropensci.org/) community.
 
 ## Get Involved
 
 There are many different ways to get involved with pyOpenSci.
 
-1. Join a community meeting: We have monthly meetings that you are welcome to attend.
-2. Submit a package to pyOpenSci. We are looking for Python packages that support scientific Python community. Read more about our [review process and scope](https://www.pyopensci.org/dev_guide/peer_review/aims_scope.html)
-3. Volunteer to be a reviewer for pyOpenSci. We are looking for people who can help review software packages as they are submitted.
-4. Spread the word! Please spread the word about this effort. And look for us this summer at the SciPy meeting in Austin, Texas!
+1. **[Join a community meeting](#community-meetings)**: We have monthly video meetings that you are welcome to attend.
+2. **[Join our community forum](https://pyopensci.discourse.group/)**. This is an online space
+   for discussion within the pyOpenSci community. Announcements for new meetings will be posted here.
+3. **Submit a package to pyOpenSci**. We are looking for Python packages that
+   support scientific Python community. Read more about our
+   [review process and scope](https://www.pyopensci.org/dev_guide/peer_review/aims_scope.html)
+4. **Volunteer to be a reviewer for pyOpenSci**. We are looking for people who
+   can help review software packages as they are submitted.
+5. **Help with technical infrastructure**. pyOpenSci has a few pieces of technical
+   infrastructure (like this site) which need maintenance and development.
+6. **Spread the word**! pyOpenSci is a community-driven project. Tell your friends,
+   recommend that a colleague submit a package, mention us at conferences, spread the word!
 
-## Who's Involved
+### Community meetings
 
-pyOpenSci is a new effort being lead by a small team of Python enthusiasts including:
+Currently, the pyOpenSci team holds community meetings roughly every 2 weeks. These are
+held remotely, and open to anyone who would like to attend. We discuss ideas for improving
+the process / technology / community management / etc of the pyOpenSci community, and
+would value your participation!
 
-* Leah Wasser, Director of Earth Analytics Education -- Earth Lab, University of Colorado -- Boulder.
-* Max Joseph, Data Scientist -- Earth Lab, University of Colorado -- Boulder.
-* Jenny Palomino, Faculty and Curriculum Developer -- Earth Lab, University of Colorado -- Boulder.
-* Chris Holdgraf, Project Jupyter, Berkeley - BIDS.
-* Luiz Irber, DIB Lab -- UC Davis
-* Paige Bailey, Google
-* Kylen Solvik, Graduate Student -- Earth Lab, University of Colorado -- Boulder.
-* Carson Farmer, External advisor -- Textile.io.
-* Leonardo Uieda, Visiting Researcher -- University of Hawai'i at Mānoa -- Honolulu.
-* Filipe Fernandes, IOOS
+The best place to find information about the next community meeting is
+[in the community forum](https://pyopensci.discourse.group). We post dates / times
+for new meetings there.
+
+### Who's Involved
+
+See our [contributors page](contributors.html) for a list of the contributors
+in the pyOpenSci community.
+
+## FAQ
+
+### What's the difference between pyOpenSci and JOSS?
+
+The [Journal of Open Source Software](https://joss.theoj.org/) is a community dedicated
+to improving the visibility and quality of scientific software. They do
+so by providing a lightweight review and publishing process so that authors
+of packages can publish their packages with a DOI and citable artifact.
+They intentionally try to avoid lengthy review and feedback cycles
+with the goal of streamlining the publishing process.
+
+pyOpenSci encourages a more hands-on approach in the review process, and
+focuses more around software best-practices than publishing.
+We encourage our reviewers to provide more hands-on assistance and
+give more in-depth feedback than is typically required in JOSS. The goal
+of pyOpenSci is to ensure that all of its packages meet a minimum level
+of best practices and standards, and our review processes often take longer
+in order to help authors reach this bar.
+
+pyOpenSci has a close relationship with JOSS, and we see these two communities
+as complementary of one another. **Any package that passes the pyOpenSci review
+process is green-lit in the JOSS process** (with the exception of a few
+JOSS-specific tasks you may need to perform). We hope that this encourages
+authors to submit to both JOSS and pyOpenSci.

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -68,8 +68,9 @@ The [Journal of Open Source Software](https://joss.theoj.org/) is a community de
 to improving the visibility and quality of scientific software. They do
 so by providing a lightweight review and publishing process so that authors
 of packages can publish their packages with a DOI and citable artifact.
-They intentionally try to avoid lengthy review and feedback cycles
-with the goal of streamlining the publishing process.
+JOSS reviews are limited in scope and the
+[submission criteria](https://joss.readthedocs.io/en/latest/review_criteria.html)
+are less stringent than those of pyOpenSci.
 
 pyOpenSci encourages a more hands-on approach in the review process, and
 focuses more around software best-practices than publishing.
@@ -81,6 +82,6 @@ in order to help authors reach this bar.
 
 pyOpenSci has a close relationship with JOSS, and we see these two communities
 as complementary of one another. **Any package that passes the pyOpenSci review and is [within scope](https://joss.readthedocs.io/en/latest/submitting.html#submission-requirements) for JOSS
-process can be fast-tracked through the JOSS review process** (with the exception of a few
+can be fast-tracked through the JOSS review process** (with the exception of a few
 JOSS-specific tasks you may need to perform). We hope that this encourages
 authors to submit to both JOSS and pyOpenSci.

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -81,6 +81,6 @@ in order to help authors reach this bar.
 
 pyOpenSci has a close relationship with JOSS, and we see these two communities
 as complementary of one another. **Any package that passes the pyOpenSci review
-process is green-lit in the JOSS process** (with the exception of a few
+process can be fast-tracked through the JOSS review process** (with the exception of a few
 JOSS-specific tasks you may need to perform). We hope that this encourages
 authors to submit to both JOSS and pyOpenSci.


### PR DESCRIPTION
Per some recent conversations on twitter and in the forum, this makes a few small updates:

* Links the front-page community members section to our dedicated community members page
* Adds links and a few more steps for getting involved
* Mentions the bi-weekly meeting
* Adds a section explaining JOSS and how we relate to it