### PR TITLE
change external links in home.md to liquid tags

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -22,7 +22,7 @@ scientific Python packages. We also build technical capacity by providing a
 curated repository of high-quality packages and enabling scientists to write
 and share their own software. We hope to foster a greater sense of community
 among scientific Python users so that we can help each other become better
-programmers and researchers. See our [list of Python packages](python-packages.html)
+programmers and researchers. See our [list of Python packages]({% link _pages/python-packages.md %})
 for an idea of the open-source projects that pyOpenSci has assisted.
 
 pyOpenSci is being modeled after the successful [rOpenSci](https://ropensci.org/) community.
@@ -57,7 +57,7 @@ for new meetings there.
 
 ### Who's Involved
 
-See our [contributors page](contributors.html) for a list of the contributors
+See our [contributors page]({% link _pages/contributors.md %}) for a list of the contributors
 in the pyOpenSci community.
 
 ## FAQ


### PR DESCRIPTION
@lwasser I converted the links to `python-packages.html` and `contributors.html` into Liquid tags that link `_pages/python-packages.md` and `_pages/contributors.md`.
(I noticed the `contributors` link was broken too).

I'm not Jekyll-fluent so I'm not 100% confident but I think this should work?
based on https://jekyllrb.com/docs/liquid/tags/#links

I'm also not sure how to set up a local env to test whether it builds, but I'm guessing you have one already.

Happy to just convert them both into hard-coded links to the external site to get it to work for now, and figure out the less-fragile way later if the Liquid tags don't work