### PR TITLE
Fix contributors page

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -153,16 +153,6 @@
   packages-submitted: [""]
   packages-reviewed: [""]
   packages-editor: [""]
-- name: Filipe Fernandes
-  bio: ''
-  organization: "Conda Forge"
-  github_username: ocefpaf
-  github_image_id: 950575
-  contributor_type:
-    - contributor
-  packages-submitted: [""]
-  packages-reviewed: [""]
-  packages-editor: [""]
 - name: Niels Bantilan
   bio: ''
   organization: ""

--- a/_pages/contributors.md
+++ b/_pages/contributors.md
@@ -21,7 +21,7 @@ of today!
 
 There are many different ways to get involved with pyOpenSci! Contributions
 of all kinds are welcome - big and small, technical and non-technical.
-For a few ideas of how you can get involved, see [the 'get involved' section]({% link _pages/home.md %}#get-involved)].
+For a few ideas of how you can get involved, see [the 'get involved' section]({% link _pages/home.md %}#get-involved).
 
 
 ## PyOpenSci Contributors

--- a/_pages/contributors.md
+++ b/_pages/contributors.md
@@ -21,7 +21,7 @@ of today!
 
 There are many different ways to get involved with pyOpenSci! Contributions
 of all kinds are welcome - big and small, technical and non-technical.
-For a few ideas of how you can get involved, see [the 'get involved' section](home.html#Get-Involved)].
+For a few ideas of how you can get involved, see [the 'get involved' section]({% link _pages/home.md %}#get-involved)].
 
 
 ## PyOpenSci Contributors


### PR DESCRIPTION
This PR fixes a couple details in the contributors page:
- Removes a duplicated contributor
- Fixes the link to the get-involved information (current link is a 404 error)
