### PR TITLE
update logo url location

### DIFF
--- a/_posts/2019-11-18-pandera-dataframe-validation.md
+++ b/_posts/2019-11-18-pandera-dataframe-validation.md
@@ -30,7 +30,7 @@ users make statistical assertions about pandas data structures.
 
 ## A Statistical Data Validation Toolkit for Pandas
 
-<img src="https://pandera.readthedocs.io/en/latest/_images/pandera-logo.svg"
+<img src="https://raw.githubusercontent.com/pandera-dev/pandera/master/docs/source/_static/pandera-logo.svg"
 width="250px">
 
 To illustrate `pandera`'s capabilities let's use a small toy example. Suppose


### PR DESCRIPTION
The readthedocs documentation no longer contains the pandera logo svg file.
This PR changes the url to the github repo, as this is the canonical place the logo
is stored.