### PR TITLE
Add Julius Busecke to contributors

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -379,3 +379,13 @@
   packages-submitted: [""]
   packages-reviewed: ["jointly"]
   packages-editor: [""]
+- name: Julius Busecke
+  bio: ''
+  organization: "Columbia University"
+  github_username: jbusecke
+  github_image_id: 14314623
+  contributor_type:
+    - reviewer
+  packages-submitted: [""]
+  packages-reviewed: ["PyGMT"]
+  packages-editor: [""]


### PR DESCRIPTION
Requested [here](https://github.com/pyOpenSci/software-review/issues/43#issuecomment-1239685595). 

I am unsure if the `github_image_id` value is right. Is there some documentation on how to obtain that number for my account? Thanks