### PR TITLE
CODE: redo of community page and added advisory

### DIFF
--- a/_data/advisory.yml
+++ b/_data/advisory.yml
@@ -1,0 +1,17 @@
+- name: Tracy Teal
+  sort: 1
+  bio: 'Executive Director, pyOpenSci'
+  organization: "RStudio"
+  twitter: 
+  github_username: tracykteal
+  github_image_id: 889238 # You can find this by right clicking on the image in your bio, and copying the link. the last part contains a 7 digit number that is your avatar image!
+  title: "Board chair"
+# Editors
+- name: Karen Cranston 
+  sort: 2
+  title: ""
+  bio: ''
+  organization: ""
+  twitter: kcranstn
+  github_username: kcranston
+  github_image_id: 312034

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -1,3 +1,46 @@
+# Staff goes here
+- name: Leah Wasser
+  sort: 3
+  bio: 'Executive Director, pyOpenSci'
+  organization: "pyOpenSci"
+  github_username: lwasser
+  github_image_id: 7649194 # You can find this by right clicking on the image in your bio, and copying the link. the last part contains a 7 digit number that is your avatar image!
+  title: "Executive Director"
+  contributor_type:
+    - leadership
+    - current editor
+    - package-maintainer
+  packages-editor: ["errdapy", "pandera", "nbless"]
+  packages-submitted: ["earthpy"]
+  packages-reviewed: [""]
+# Editors
+- name: David Nicholson
+  sort: 2
+  title: "Editor in Chief"
+  bio: ''
+  organization: ""
+  github_username: NickleDave
+  github_image_id: 11934090
+  contributor_type:
+    - current editor
+    - contributor
+  packages-submitted: [""]
+  packages-reviewed: ["pystiche"]
+  packages-editor: [""]
+- name: Ivan Ogasawara
+  sort: 1
+  bio: 'SciPy Latin America Ambassador'
+  organization: "SciPy Latin America, Ibis-framework"
+  github_username: xmnlab
+  github_image_id: 5209757
+  title: "Editor"
+  contributor_type:
+    - reviewer
+    - current-editor
+  packages-submitted: [""]
+  packages-reviewed: ["pandera"]
+  packages-editor: ["sevivi"]
+# Reviewers & maintainers go here
 - name: Ariane Sasso
   bio: 'Researcher in Medical Informatics and Digital Health'
   organization: "Hasso Plattner Institute"
@@ -7,18 +50,6 @@
     - package-maintainer
   packages-editor: [""]
   packages-submitted: ["devicely"]
-  packages-reviewed: [""]
-- name: Leah Wasser
-  bio: 'Executive Director, pyOpenSci'
-  organization: "pyOpenSci"
-  github_username: lwasser
-  github_image_id: 7649194 # You can find this by right clicking on the image in your bio, and copying the link. the last part contains a 7 digit number that is your avatar image!
-  contributor_type:
-    - leadership
-    - editor
-    - package-maintainer
-  packages-editor: ["errdapy", "pandera", "nbless"]
-  packages-submitted: ["earthpy"]
   packages-reviewed: [""]
 - name: Chris Holdgraf
   bio: 'Bio Here'
@@ -37,21 +68,9 @@
   github_username: mbjoseph
   github_image_id: 2664564
   contributor_type:
-    - leadership
     - reviewer
   packages-submitted: [""]
   packages-reviewed: ["pandera"]
-- name: Ivan Ogasawara
-  bio: 'SciPy Latin America Ambassador'
-  organization: "SciPy Latin America, Ibis-framework"
-  github_username: xmnlab
-  github_image_id: 5209757
-  contributor_type:
-    - reviewer
-    - editor
-  packages-submitted: [""]
-  packages-reviewed: ["pandera"]
-  packages-editor: ["sevivi"]
 - name: Luiz Irber
   bio: ''
   organization: "DIB Lab -- UC Davis"
@@ -59,7 +78,6 @@
   github_image_id: 6642
   contributor_type:
     - editor
-    - leadership
   packages-submitted: [""]
   packages-reviewed: [""]
   packages-editor: ["earthpy"]
@@ -89,7 +107,6 @@
   github_username: jlpalomino
   github_image_id: 4017492
   contributor_type:
-    - leadership
     - reviewer
     - contributor
   packages-editor: [""]
@@ -205,16 +222,6 @@
     - reviewer
   packages-submitted: [""]
   packages-reviewed: ["earthpy"]
-  packages-editor: [""]
-- name: David Nicholson
-  bio: ''
-  organization: ""
-  github_username: NickleDave
-  github_image_id: 11934090
-  contributor_type:
-    - contributor
-  packages-submitted: [""]
-  packages-reviewed: ["pystiche"]
   packages-editor: [""]
 - name: Anita Graser
   bio: ''

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -6,7 +6,7 @@ main:
     url: /blog/
   - title: "Resources"
     url: /resources/
-  - title: "Contributors"
-    url: /contributors/
+  - title: "Our Community"
+    url: /our-community/
   - title: "Get In Touch"
     url: /get-involved-contact/

--- a/_pages/contributors.md
+++ b/_pages/contributors.md
@@ -1,52 +1,90 @@
 ---
-layout: single
-permalink: /contributors/
-title: "pyOpenSci Contributors"
+layout: splash
+permalink: /our-community/
+title: "The pyOpenSci Team & Contributors"
+excerpt: "pyOpenSci is a diverse community of people interested in building a community of practice around scientific software written in Python."
 classes:
 header:
     overlay_image: images/header.jpg
     overlay_filter: 0.6
 ---
 
-## Who Is Involved with PyOpenSci?
-
-pyOpenSci is a diverse community of people interested in building
-a community of practice around scientific software in Python.
+## Our pyOpenSci Community 
 
 {{ site.data.contributors | size }} people have contributed to pyOpenSci as
 of today!
 
-
-## How Can I Contribute?
+<!-- ## How Can I Contribute?
 
 There are many different ways to get involved with pyOpenSci! Contributions
-of all kinds are welcome - big and small, technical and non-technical.
-For a few ideas of how you can get involved, see [the 'get involved' section]({% link _pages/home.md %}#get-involved).
+of all kinds are welcome - big and small, technical and non-technical. -->
 
 
-## PyOpenSci Contributors
 
-Below is a relatively up-to-date list of active contributors
+## PyOpenSci Team & Contributors
+
+
+{% assign ppl_sorted = site.data.contributors | sort: 'sort' | reverse %}
 
 <div class="entries-grid">
-{% for aperson in site.data.contributors %}
+{% for aperson in ppl_sorted %}
  <div class="grid__item">
    <article class="archive__item" itemscope="" itemtype="https://schema.org/CreativeWork">
-       <!-- do we really want images? it looks nicer that is for sure
-       i was thinking it would be nicer to have a grid that expands over time rather than a list but am option to options-->
        {% if aperson.github_image_id %}
-         <div class="archive__item-teaser">
-           <img src="https://avatars1.githubusercontent.com/u/{{ aperson.github_image_id }}?s=200&v=4" alt="">
+         <div class="archive__item-teaser tall">
+           <img src="https://avatars1.githubusercontent.com/u/{{ aperson.github_image_id }}?s=400&v=4" alt="">
          </div>
        {% endif %}
      <h4 class="archive__item-title" itemprop="headline">
          <a href="https://www.github.com/{{ aperson.github_username }}" rel="permalink"> {{ aperson.name }}
- </a>
+        </a>
      </h4>
+     <p class="page__meta">
+     {% if aperson.title %}
+      <span>{{ aperson.title }}</span>
+     {% endif %}
+     </p>
+     <!-- Contribution types -->
+     <p class="page__meta">
+     <span class="page__meta-readtime">
+      {% for atype in aperson.contributor_type %}
+      {{ atype }} {% if forloop.last == false %}* {% endif %}
+      {% endfor %}
+    </span>
+    </p>
      <p class="contrib_org" itemprop="organization"> {{ aperson.organization }} </p>
-     <!--<p class="archive__item-excerpt" itemprop="description"> {{ aperson.bio }} </p>-->
-
    </article>
  </div>
 {% endfor %}
 </div>
+
+
+<h2 class="clearall">  External advisory committee</h2>
+
+{% assign advisory_sorted = site.data.advisory | sort: 'sort' %}
+
+<div class="entries-grid">
+{% for aperson in advisory_sorted %}
+ <div class="grid__item">
+   <article class="archive__item" itemscope="" itemtype="https://schema.org/CreativeWork">
+       {% if aperson.github_image_id %}
+         <div class="archive__item-teaser tall">
+           <img src="https://avatars1.githubusercontent.com/u/{{ aperson.github_image_id }}?s=400&v=4" alt="">
+         </div>
+       {% endif %}
+     <h4 class="archive__item-title" itemprop="headline">
+         <a href="https://www.github.com/{{ aperson.github_username }}" rel="permalink"> {{ aperson.name }}
+        </a>
+     </h4>
+     <p class="page__meta">
+     {% if aperson.title %}
+      <span>{{ aperson.title }}</span>
+     {% endif %}
+     </p>
+     <p class="contrib_org" itemprop="organization"> {{ aperson.organization }} </p>
+   </article>
+ </div>
+{% endfor %}
+</div>
+
+

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -77,6 +77,14 @@ body {font-size:90%}
   font-size: .92em!important;
 }
 
+/* Fix people page - allow for tall images */
+.archive__item-teaser.tall {
+  max-height: 320px!important;
+}
+
+h2.clearall {
+  clear: both;
+}
 
 /* Fix buttons and text in notice boxes */
 .notice--info .btn.btn--info {


### PR DESCRIPTION
This pr:

* Updates the community page and adds a "title" for people who are day to day involved in operations
* Moves editors (current) up in the list
* Adds advisory committee to the page (it's at the bottom now so I want to think about this as the community list grows. We may want to have reviewers and maintainers listed separately in the future given how big that will become.

<img width="1149" alt="Screen Shot 2022-09-26 at 2 10 43 PM" src="https://user-images.githubusercontent.com/7649194/192370605-8f6914b5-9e54-4e0f-9b62-2d55f8a28f06.png">
<img width="1056" alt="Screen Shot 2022-09-26 at 2 10 50 PM" src="https://user-images.githubusercontent.com/7649194/192370596-ceb6d536-a694-43a3-8794-57f5c2f63eef.png">