### PR TITLE
STYLE: Fix header issue remove extra spaces

### DIFF
--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -85,7 +85,7 @@
 - package-name: phenopype
   description: 'A phenotyping pipeline for Python.'
   maintainer: ["Moritz Lürig"]
-  link: "https://github.com/mluerig/phenopype"
+  link: "https://github.com/phenopype/phenopype"
   date-accepted:
   highlight:
   docs-url: 

--- a/_includes/category-list.html
+++ b/_includes/category-list.html
@@ -1,0 +1,25 @@
+{% case site.category_archive.type %}
+  {% when "liquid" %}
+    {% assign path_type = "#" %}
+  {% when "jekyll-archives" %}
+    {% assign path_type = nil %}
+{% endcase %}
+
+{% if site.category_archive.path %}
+  {% assign categories_sorted = page.categories | sort_natural %}
+
+  <p class="page__taxonomy">
+    <strong><i class="fas fa-fw fa-folder-open" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].categories_label | default: "Categories:" }} </strong>
+    <span itemprop="keywords">
+    {% for category_word in categories_sorted %}
+    <span class="page__taxonomy-item p-category">
+      <!-- <a href="{{ category_word | slugify | prepend: path_type | prepend: site.category_archive.path | relative_url }}" class="page__taxonomy-item p-category" rel="tag"> -->
+        {{ category_word }}
+    <!-- </a> -->
+        {% unless forloop.last %}
+    </span>
+        <span class="sep">, </span>{% endunless %}
+    {% endfor %}
+    </span>
+  </p>
+{% endif %}

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,7 +1,6 @@
+<!-- custom head content-->
 <link rel="icon" href="/images/favicon.ico" type="image/x-icon">
-
-<div data-proofer-ignore>
 <link rel="preconnect" href="https://fonts.googleapis.com" data-proofer-ignore>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin data-proofer-ignore>
 <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@200;400;700family=Open+Sans:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet" data-proofer-ignore>
-</div>
+<!-- END custom head content-->


### PR DESCRIPTION
This should remove the extra spaces from the head include that i think was breaking where it placed that head element in the code. a really weird bug however if that is the issue. 

This does a few things:

* Removes links to categories at blog base as we don't have those pages yet - this should fix many broken link flags
* Fixes fonts (google) wasn't rendering in `head` was in the `body` not sure why but it's fixed
* Fixes a few broken links - still some more but chipping away. 
