### PR TITLE
INFRA: fix and cleanup community grid

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -140,6 +140,8 @@ author:
 
 # Site Footer
 footer:
+  scripts:
+    - https://kit.fontawesome.com/2409929a54.js
   links:
     - label: "Twitter"
       icon: "fab fa-fw fa-twitter-square"

--- a/_data/advisory.yml
+++ b/_data/advisory.yml
@@ -6,6 +6,7 @@
   github_username: tracykteal
   github_image_id: 889238 # You can find this by right clicking on the image in your bio, and copying the link. the last part contains a 7 digit number that is your avatar image!
   title: "Board chair"
+  board: true
 # Editors
 - name: Karen Cranston 
   sort: 2
@@ -15,3 +16,4 @@
   twitter: kcranstn
   github_username: kcranston
   github_image_id: 312034
+  board: true

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -33,6 +33,9 @@
   bio: ''
   organization: ""
   twitter: kcranstn
+  mastodon: 
+  orcidid: 
+  website: 
   github_username: kcranston
   github_image_id: 312034
   board: true
@@ -124,6 +127,10 @@
   organization: ""
   github_username: NickleDave
   github_image_id: 11934090
+  twitter: 
+  mastodon: 
+  orcidid: 
+  website: 
   contributor_type:
     - current editor
     - contributor
@@ -137,6 +144,10 @@
   github_username: arianesasso
   github_image_id: 3659681
   editorial-board: true
+  twitter: 
+  mastodon: 
+  orcidid: 
+  website: 
   contributor_type:
     - package-maintainer
     - editor
@@ -150,6 +161,10 @@
   github_username: jlpalomino
   github_image_id: 4017492
   editorial-board: true
+  twitter: 
+  mastodon: 
+  orcidid: 
+  website: 
   contributor_type:
     - reviewer
     - contributor
@@ -165,6 +180,9 @@
   focus-areas: ["gis", "spatial-vector-data"]
   github_username: anitagraser
   github_image_id: 590385
+  mastodon: 
+  orcidid: 
+  website: 
   contributor_type:
     - package-maintainer
   packages-submitted: ["movingpandas"]
@@ -177,6 +195,10 @@
   organization: "Berkeley Bids, Project Jupyter, Binder"
   github_username: choldgraf
   github_image_id: 1839645
+  twitter: 
+  mastodon: 
+  orcidid: 
+  website: 
   contributor_type:
     - leadership
     - editor
@@ -188,6 +210,10 @@
   organization: "Earth Lab, University of Colorado - Boulder"
   github_username: mbjoseph
   github_image_id: 2664564
+  twitter: 
+  mastodon: 
+  orcidid: 
+  website: 
   contributor_type:
     - reviewer
   packages-submitted: [""]

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -1,11 +1,16 @@
 # Staff goes here
 - name: Leah Wasser
-  sort: 3
+  sort: 1
   bio: 'Executive Director, pyOpenSci'
   organization: "pyOpenSci"
   github_username: lwasser
   github_image_id: 7649194 # You can find this by right clicking on the image in your bio, and copying the link. the last part contains a 7 digit number that is your avatar image!
   title: "Executive Director"
+  twitter: leahawasser
+  mastodon: 
+  orcidid: 
+  website: https://www.leahwasser.com
+  board: true
   contributor_type:
     - leadership
     - current editor
@@ -13,6 +18,24 @@
   packages-editor: ["errdapy", "pandera", "nbless"]
   packages-submitted: ["earthpy"]
   packages-reviewed: [""]
+- name: Tracy Teal
+  sort: 2
+  bio: ''
+  organization: "RStudio"
+  twitter: 
+  github_username: tracykteal
+  github_image_id: 889238 # You can find this by right clicking on the image in your bio, and copying the link. the last part contains a 7 digit number that is your avatar image!
+  title: "Board chair"
+  board: true
+- name: Karen Cranston 
+  sort: 3
+  title: ""
+  bio: ''
+  organization: ""
+  twitter: kcranstn
+  github_username: kcranston
+  github_image_id: 312034
+  board: true
 ## Advisory team
 - name: Leonardo Uieda
   advisory: true
@@ -20,8 +43,12 @@
   organization: "University of Liverpool, JOSS"
   github_username:
   github_image_id: 290082
+  twitter: 
+  mastodon: 
+  orcidid: 
+  website: 
   contributor_type:
-    - contributor
+    #- contributor
   packages-submitted: [""]
   packages-reviewed: [""]
   packages-editor: [""]
@@ -32,11 +59,15 @@
   organization: "SciPy Latin America, Ibis-framework"
   github_username: xmnlab
   github_image_id: 5209757
-  title: "Editor"
-  editor: true # can say emeritus when they step down?
+  twitter: 
+  mastodon: 
+  orcidid: 
+  website: 
+  #title: "Alumni Editor"
+  editor: #true # can say emeritus when they step down?
   contributor_type:
     - reviewer
-    - current-editor
+    - alumni-editor
   packages-submitted: [""]
   packages-reviewed: ["pandera"]
   packages-editor: ["sevivi"]
@@ -45,9 +76,13 @@
   bio: ''
   organization: "IOOS, Conda Forge"
   github_username: ocefpaf
+  twitter: 
+  mastodon: 
+  orcidid: 
+  website: 
   github_image_id: 950575
   contributor_type:
-    - contributor
+    #- contributor
   packages-submitted: ["errdapy"]
   packages-reviewed: [""]
   packages-editor: [""]
@@ -57,8 +92,12 @@
   organization: ""
   github_username: lheagy
   github_image_id: 6361812
+  twitter: 
+  mastodon: 
+  orcidid: 
+  website: 
   contributor_type:
-    - contributor
+    #- contributor
   packages-submitted: [""]
   packages-reviewed: [""]
   packages-editor: [""]
@@ -71,6 +110,7 @@
   twitter: martinfleis
   mastodon: martinfleis@mastodon.social
   orcidid: 0000-0003-3319-3366
+  website: 
   contributor_type:
     - reviewer
   packages-submitted: [""]
@@ -79,7 +119,7 @@
 - name: David Nicholson
   sort: 2
   title: "Editor in Chief"
-  editor: true
+  editorial-board: true
   bio: 'Bio goes here just a sentence or two is great!'
   organization: ""
   github_username: NickleDave
@@ -96,7 +136,7 @@
   title: "Editor"
   github_username: arianesasso
   github_image_id: 3659681
-  editor: true
+  editorial-board: true
   contributor_type:
     - package-maintainer
     - editor
@@ -109,7 +149,7 @@
   organization: "Google Cloud Learning Services"
   github_username: jlpalomino
   github_image_id: 4017492
-  editor: true
+  editorial-board: true
   contributor_type:
     - reviewer
     - contributor
@@ -121,7 +161,7 @@
   bio: 'Researcher, open source GIS developer and author.'
   organization: "AIT Austrian Institute of Technology"
   title: "Editor"
-  editor: true
+  editorial-board: true
   focus-areas: ["gis", "spatial-vector-data"]
   github_username: anitagraser
   github_image_id: 590385

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -8,7 +8,7 @@
   title: "Executive Director"
   twitter: leahawasser
   mastodon: 
-  orcidid: 
+  orcidid: 0000-0002-8177-6550
   website: https://www.leahwasser.com
   board: true
   contributor_type:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,28 @@
+<meta charset="utf-8">
+
+{% include seo.html %}
+
+{% unless site.atom_feed.hide %}
+  <link href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ site.title }} Feed">
+{% endunless %}
+
+<!-- https://t.co/dKP3o1e -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<script>
+  document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';
+</script>
+
+<!-- For all browsers -->
+<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+
+<!-- Remove font awesome as it doesn't support accessibility when loaded this way
+<link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css"></noscript>
+-->
+
+{% if site.head_scripts %}
+  {% for script in site.head_scripts %}
+    <script src="{{ script | relative_url }}"></script>
+  {% endfor %}
+{% endif %}

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -3,4 +3,6 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&family=Raleway:wght@200;300;400;600&display=swap" rel="stylesheet"> 
+<script src="https://kit.fontawesome.com/2409929a54.js" crossorigin="anonymous"></script>
+
 <!-- END custom head content-->

--- a/_includes/people-grid.html
+++ b/_includes/people-grid.html
@@ -17,12 +17,24 @@
       <p class="contrib_org" itemprop="organization"> {{ aperson.organization }} </p>
       <div class="ppl_social">
       {% if aperson.twitter %}
-      <a href="https://www.twitter.com/{{ aperson.twitter }}"><img src="https://d33wubrfki0l68.cloudfront.net/d1b2a46a9e7ca4ef892f4fecb6cd823e96b20c43/937bf/images/users/twitter.svg" alt="Small graphic showing the Twitter icon. The users twitter account is linked to here if you click on the icon.">
+      <a href="https://www.twitter.com/{{ aperson.twitter }}">
+        <span class="fa-brands fa-twitter" title="Click to view {{ aperson.title }}'s Twitter account"></span>
       </a>
       {% endif %}
       {% if aperson.github_username %}
-      <a href="https://www.github.com/{{ aperson.github_username }}"><img src="https://d33wubrfki0l68.cloudfront.net/57b49d06f9d21448da7139f8f6a1addb9942b720/4f69a/images/users/github.svg" alt="Small graphic showing the GitHub icon. The users GitHub account is linked to here if you click on the icon.">
+      <a href="https://www.github.com/{{ aperson.github_username }}"><span class="fa-brands fa-github" title="Click to view {{ aperson.title }}'s GitHub account"></span>
       </a>
+      {% endif %}
+      {% if aperson.website %}
+      <a href="{{ aperson.website }}"><span class="fa-solid fa-blog" title="Click to view {{ aperson.title }}'s Website"></span>
+      </a>
+      {% endif %}
+      {% if aperson.orcidid %}
+      <a href="https://orcid.org/{{ aperson.orcidid }}"><span class="fa-brands fa-orcid" title="Click to view {{ aperson.title }} on fa-orcid"></span>
+      </a>
+      {% endif %}
+      {% if aperson.mastodon %}
+      <span class="fa-brands fa-mastodon grey" title="{{ aperson.name }} is on Mastadon"></span>
       {% endif %}
     </div>
     </article>

--- a/_includes/people-grid.html
+++ b/_includes/people-grid.html
@@ -1,0 +1,29 @@
+<div class="grid__item">
+    <article class="archive__item" itemscope="" itemtype="https://schema.org/CreativeWork">
+        {% if aperson.github_image_id %}
+          <div class="person_img">
+            <img src="https://avatars1.githubusercontent.com/u/{{ aperson.github_image_id }}?s=400&v=4" alt="GitHub photo of {{ aperson.name }}">
+          </div>
+        {% endif %}
+      <h4 class="person_name" itemprop="headline">
+          <a href="https://www.github.com/{{ aperson.github_username }}" rel="permalink"> {{ aperson.name }}
+         </a>
+      </h4>
+      <p class="page__meta">
+      {% if aperson.title %}
+       <span>{{ aperson.title }}</span>
+      {% endif %}
+      </p>
+      <p class="contrib_org" itemprop="organization"> {{ aperson.organization }} </p>
+      <div class="ppl_social">
+      {% if aperson.twitter %}
+      <a href="https://www.twitter.com/{{ aperson.twitter }}"><img src="https://d33wubrfki0l68.cloudfront.net/d1b2a46a9e7ca4ef892f4fecb6cd823e96b20c43/937bf/images/users/twitter.svg" alt="Small graphic showing the Twitter icon. The users twitter account is linked to here if you click on the icon.">
+      </a>
+      {% endif %}
+      {% if aperson.github_username %}
+      <a href="https://www.github.com/{{ aperson.github_username }}"><img src="https://d33wubrfki0l68.cloudfront.net/57b49d06f9d21448da7139f8f6a1addb9942b720/4f69a/images/users/github.svg" alt="Small graphic showing the GitHub icon. The users GitHub account is linked to here if you click on the icon.">
+      </a>
+      {% endif %}
+    </div>
+    </article>
+  </div>

--- a/_pages/about-peer-review.md
+++ b/_pages/about-peer-review.md
@@ -127,45 +127,15 @@ are, in places, less stringent than those of pyOpenSci.
 We value our volunteer editors. Learn more about what editors do and how we select
 them here. 
 
-{% assign editors = site.data.contributors | where: 'editor', true %}
+{% assign editors = site.data.contributors | where: 'editor', true | sort: 'sort' | reverse %}
 
-<div class="grid people">
+<div class="entries-grid">
 {% for aperson in editors %}
-   <article class="person__item" itemscope="" itemtype="https://schema.org/CreativeWork">
-       {% if aperson.github_image_id %}
-         <div>
-           <img src="https://avatars1.githubusercontent.com/u/{{ aperson.github_image_id }}?s=400&v=4" alt="image of {{ aperson.name}}" class="contrib_avatar">
-         </div>
-       {% endif %}
-      <div class="about_person">
-     <h4 class="grid_title" itemprop="headline">
-         <a href="https://www.github.com/{{ aperson.github_username }}" rel="permalink"> {{ aperson.name }}
-         </a>
-     </h4>
-     <p class="page__meta title">
-     {% if aperson.title %}
-      {{ aperson.title }}
-     {% endif %}
-     </p>
-     <p class="page__meta focus-areas">
-      {% if aperson.focus-areas %}
-      {% for anArea in aperson.focus-areas %}
-        {{ anArea }}{% if forloop.last == false %}, {% endif %} 
-        {% endfor %}
-      {% endif %}
-     </p>
-     </div>
-     <!-- Contribution types -->
-     <p class="page__meta bio">
-     <span>
-     {{ aperson.name}} is also a
-       {% for atype in aperson.contributor_type %}
-      {{ atype }}{% if forloop.last == false %}, {% endif %} 
-      {% endfor %} for pyOpenSci.
-    </span>
-    </p>
-     <p class="contrib_org" itemprop="organization"> Affiliation: {{ aperson.organization }} </p>
-   </article>
+{% unless aperson.board %}
+  {% unless aperson.advisory %}
+    {% include people-grid.html  %}
+ {% endunless %}
+ {% endunless %}
 {% endfor %}
 </div>
 

--- a/_pages/contributors.md
+++ b/_pages/contributors.md
@@ -16,36 +16,20 @@ redirect_from:
 <!-- 
 {{ site.data.contributors | size }} people have contributed to pyOpenSci as
 of today! 
-
-TODO add this role to the governance 
+TODO add this advisory committee role to the governance 
 -->
 
-## External advisory committee
+pyOpenSci has one core paid staff member who leads the organization. We are supported 
+by an expert team of volunteer advisory members who help steer the direction of the organization.
+
+## External advisory committee & leadership
 {: .clearall }
 
-{% assign advisory_sorted = site.data.advisory | sort: 'sort' %}
+{% assign advisory_sorted = site.data.contributors | where:"board",true | sort: 'sort' %}
 
 <div class="entries-grid">
 {% for aperson in advisory_sorted %}
- <div class="grid__item">
-   <article class="archive__item" itemscope="" itemtype="https://schema.org/CreativeWork">
-       {% if aperson.github_image_id %}
-         <div class="archive__item-teaser tall">
-           <img src="https://avatars1.githubusercontent.com/u/{{ aperson.github_image_id }}?s=400&v=4" alt="">
-         </div>
-       {% endif %}
-     <h4 class="archive__item-title" itemprop="headline">
-         <a href="https://www.github.com/{{ aperson.github_username }}" rel="permalink"> {{ aperson.name }}
-        </a>
-     </h4>
-     <p class="page__meta">
-     {% if aperson.title %}
-      <span>{{ aperson.title }}</span>
-     {% endif %}
-     </p>
-     <p class="contrib_org" itemprop="organization"> {{ aperson.organization }} </p>
-   </article>
- </div>
+  {% include people-grid.html  %}
 {% endfor %}
 </div>
 
@@ -55,77 +39,31 @@ TODO add this role to the governance
 pyOpenSci advisory committee members are volunteer experts in the scientific Python open 
 source space who provide high-level guidance on the development of the organization. 
 
-{% assign advisory_working = site.data.contributors | "advisory" == true | sort: 'sort' %}
+{% assign advisory_working = site.data.contributors | where:"advisory",true | sort: 'sort' %}
 
 <div class="entries-grid">
 {% for aperson in advisory_working %}
   {% if aperson.advisory %}
- <div class="grid__item">
-   <article class="archive__item" itemscope="" itemtype="https://schema.org/CreativeWork">
-       {% if aperson.github_image_id %}
-         <div class="archive__item-teaser tall">
-           <img src="https://avatars1.githubusercontent.com/u/{{ aperson.github_image_id }}?s=400&v=4" alt="">
-         </div>
-       {% endif %}
-     <h4 class="archive__item-title" itemprop="headline">
-         <a href="https://www.github.com/{{ aperson.github_username }}" rel="permalink"> {{ aperson.name }}
-        </a>
-     </h4>
-     <p class="page__meta">
-     {% if aperson.title %}
-      <span>{{ aperson.title }}</span>
-     {% endif %}
-     </p>
-     <!-- Contribution types -->
-     <p class="page__meta">
-     <span class="page__meta-readtime">
-      {% for atype in aperson.contributor_type %}
-      {{ atype }} {% if forloop.last == false %}* {% endif %}
-      {% endfor %}
-    </span>
-    </p>
-     <p class="contrib_org" itemprop="organization"> {{ aperson.organization }} </p>
-   </article>
- </div>
+    {% include people-grid.html  %}
  {% endif %}
 {% endfor %}
 </div>
 
 
-## PyOpenSci Team & Contributors
+## PyOpenSci community contributors
 {: .clearall }
 
 {% assign ppl_sorted = site.data.contributors | sort: 'sort' | reverse %}
 
 <div class="entries-grid">
 {% for aperson in ppl_sorted %}
- <div class="grid__item">
-   <article class="archive__item" itemscope="" itemtype="https://schema.org/CreativeWork">
-       {% if aperson.github_image_id %}
-         <div class="archive__item-teaser tall">
-           <img src="https://avatars1.githubusercontent.com/u/{{ aperson.github_image_id }}?s=400&v=4" alt="">
-         </div>
-       {% endif %}
-     <h4 class="archive__item-title" itemprop="headline">
-         <a href="https://www.github.com/{{ aperson.github_username }}" rel="permalink"> {{ aperson.name }}
-        </a>
-     </h4>
-     <p class="page__meta">
-     {% if aperson.title %}
-      <span>{{ aperson.title }}</span>
-     {% endif %}
-     </p>
-     <!-- Contribution types -->
-     <p class="page__meta">
-     <span class="page__meta-readtime">
-      {% for atype in aperson.contributor_type %}
-      {{ atype }} {% if forloop.last == false %}* {% endif %}
-      {% endfor %}
-    </span>
-    </p>
-     <p class="contrib_org" itemprop="organization"> {{ aperson.organization }} </p>
-   </article>
- </div>
+  {% unless aperson.board %}
+  {% unless aperson.advisory %}
+  {% unless aperson.editorial-board %}
+    {% include people-grid.html  %}
+  {% endunless %}
+  {% endunless %}
+  {% endunless %}
 {% endfor %}
 </div>
 

--- a/_posts/2022-10-24-why-should-python-open-source-matter-science.md
+++ b/_posts/2022-10-24-why-should-python-open-source-matter-science.md
@@ -3,7 +3,7 @@ layout: single
 title: "Why should Python open source package health matter to scientists? (and to you!)"
 excerpt: "Free and open source software tools are the foundation for thousands if not millions of scientific workflows. Yet, it is rare that users fully understand it's importance in moving science forward. Here, I discuss the value of free and open source software for science; why you as a scientist should care; and what pyOpenSci is doing to try to support Python scientific tools for science. "
 author: "Leah Wasser"
-permalink: /blog/why-python-open-source-software-matters-for-scientists
+permalink: /blog/why-python-open-source-software-matters-for-scientists.html
 header:
     overlay_color: "#666"
     overlay_filter: 0.6
@@ -234,7 +234,7 @@ efforts that determine metrics and customize them to our needs.
 
 
 
-[In the next post, I will recap that convo on twitter.](/blog/what-makes-a-python-package-healthy)
+[In the next post, I will recap that convo on twitter.](/blog/what-makes-open-source-python-package-healthy.html)
 
 ## Feedback? Leave it below 
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -59,6 +59,11 @@ h3 {
   font-size: $type-size-3!important;
 }
 
+.wide #main {
+  padding-left: 6em;
+  padding-right: 6em;
+}
+
 .archive__item-title {
   font-family: $header-font-family!important;
   font-size: .9em !important;
@@ -83,15 +88,50 @@ h3 {
   border-radius: 50%;
 }
 
+.ppl_img {
+  padding-left: 2em;
+  padding-right: 2em;
+}
+
+.ppl_social a {
+  margin-right: 10px;
+}
+
+.grid.people {
+  grid-gap: 60px;
+}
+.person__item {
+  //margin: 2.2em;
+  text-align: center;
+}
+
+h4.person_name {
+    margin-top: 0.6em;
+    margin-bottom: 0;
+    font-size: 1.3em;
+  a {
+    text-decoration: none;
+  }
+}
+
+.person_img {
+  -webkit-filter: drop-shadow(3px 3px 3px #999);
+  filter: drop-shadow(3px 3px 3px #999);
+}
+
+.person_img img {
+  width: 100%;
+}
+
 /* Create & style a 3x3 grid wrapper */
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  grid-gap: .3rem;
+  grid-gap: 10px;
 
   h4.grid_title {
-    font-size: 1.4em;
-    text-align: center;
+    font-size: 1.6em;
+    margin-top: 1em;
   }
   .grid_title {
     margin-bottom: 0
@@ -99,9 +139,6 @@ h3 {
 
   h4.grid_title a {
     text-decoration: none;
-  }
-  .person__item {
-    margin: 2.2em;
   }
 
   .page__meta.title {


### PR DESCRIPTION
This cleans up the grid for all people blocks and makes a uniform layout via an include template. 

It also adds the ability for people to list
* website
* orcid
* twitter
* mastadon
* adds their github which we have for pretty much everyone

Finally it adds the advisory committees and a clearer leadership structure which will also be reflected in governance soon.

```
  twitter: leahawasser
  mastodon: 
  orcidid: 
  website: https://www.leahwasser.com
```
TODO: add links to orcid with a logo as well. and add a website link as well.

We may want a little blurb for leadership in the near future.

<img width="607" alt="Screen Shot 2022-11-08 at 6 21 20 PM" src="https://user-images.githubusercontent.com/7649194/200697173-02dba59e-70dc-4a64-a172-f304ec66590d.png">

 