### PR TITLE
FEAT: add editorial board back and move packages to grid template

### DIFF
--- a/_includes/archive-cards.html
+++ b/_includes/archive-cards.html
@@ -1,21 +1,18 @@
 <!-- This is a layout for 3 cards - it is a flex box -->
-<!--  -->
-<div class="feature__item">
-    <a href="{{ post.url}}">
+<article>
+<a href="{{ post.url}}">
+<div class="cards">
     {% if post.feature_img %}
     <img src="{{ post.feature_img }}" alt="{{ post.feature_alt }}">
     {% endif %}
-<div class="card">
     
-    <div class="archive__item">
-    <div class="archive__item-body">
+    <div class="card__bkg">
         <h3 class="card-title">{{ post.title | markdownify | strip_html | truncate: 60 }}</h3>
-        <div class="card-excerpt">
-            <p>{{ post.excerpt | truncate: 100}}</p>
-        </div>
     </div>
+    <div class="card-excerpt">
+        <p>{{ post.excerpt | truncate: 100}}</p>
     </div>
+</div>
 </a>
-</div>
-</div>
+</article>
 

--- a/_includes/package-grid.html
+++ b/_includes/package-grid.html
@@ -1,0 +1,36 @@
+<!-- A template for lists of packages -->
+
+<div class="cards">
+    <article class="archive__item" itemscope="" itemtype="https://schema.org/CreativeWork">
+        <h3 class="card__title no_toc" itemprop="headline">
+            {{ apackage.package-name }}
+        </h3>
+        <p class="page__meta contributors">
+         <span><i class="fas fa-feather" aria-hidden="true"></i>
+         <!-- Commas in between authors -->
+         {% for aMaintainer in apackage.maintainer %}  
+         {{ aMaintainer }}{% if forloop.last == false %}, {% endif %}
+         {% endfor %}
+         </span>
+        </p>
+        <span class="narrow">
+        <p class="archive__item-excerpt narrow" itemprop="description">{{ apackage.description | markdownify }}
+        </p>
+        </span>
+        <ul>
+          <li>
+            <a href="{{ apackage.link }}" rel="permalink"><i class="fab fa-github"></i> View Code </a>
+          </li>
+          {% if apackage.docs-url %}
+          <li>
+            <a href="{{ apackage.docs-url }}" rel="permalink"><i class="fas fa-book-open"></i> View Docs</a>
+          </li>
+          {% endif %}
+          {% if apackage.citation-link %}
+          <li>
+            <a href="{{ apackage.docs-url }}" rel="permalink"><i class="fas fa-bookmark fa-fw"></i> Cite</a>
+          </li>
+        {% endif %}
+        </ul>
+    </article>
+    </div>

--- a/_layouts/posts_gallery.html
+++ b/_layouts/posts_gallery.html
@@ -4,7 +4,6 @@ layout: archive
 
 {{ content }}
 
-
 <ul class="taxonomy__index">
   {% assign postsInYear = site.posts | where_exp: "item", "item.hidden != true" | group_by_exp: 'post', 'post.date | date: "%Y"' %}
   {% for year in postsInYear %}
@@ -21,9 +20,8 @@ layout: archive
 {% for year in postsByYear %}
   <section id="{{ year.name }}" class="taxonomy__section">
     <h2 class="archive__subtitle">{{ year.name }}</h2>
-    <div class="entries-{{ entries_layout }}">
+    <div class="blog__grid">
       {% for post in year.items %}
-        {% comment %}{% include archive-single.html type=entries_layout %}{% endcomment %}
         {% include archive-cards.html %}
       {% endfor %}
     </div>

--- a/_pages/about-peer-review.md
+++ b/_pages/about-peer-review.md
@@ -127,7 +127,7 @@ are, in places, less stringent than those of pyOpenSci.
 We value our volunteer editors. Learn more about what editors do and how we select
 them here. 
 
-{% assign editors = site.data.contributors | where: 'editor', true | sort: 'sort' | reverse %}
+{% assign editors = site.data.contributors | where: 'editorial-board', true | sort: 'sort' | reverse %}
 
 <div class="entries-grid">
 {% for aperson in editors %}
@@ -140,3 +140,17 @@ them here.
 </div>
 
 <br style="clear:both">
+
+## Recently Accepted Python Packages
+
+<div class="grid">
+    {% for apackage in site.data.packages %}
+    {% if apackage.highlight %}
+{% include package-grid.html  %}
+    {% endif %}
+    {% endfor %}
+</div>
+
+<br clear="both">
+
+   <a href="/python-packages/" class="btn btn--info">View All Accepted Packages <i class="fa fa-4 fa-arrow-circle-right" aria-hidden="true"></i></a>

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -7,7 +7,7 @@ excerpt: "Here we will both post updates about pyOpenSci and also highlight cont
 header:
     overlay_color: "#666"
     overlay_filter: 0.6
-author_profile: true
+author_profile: false
 ---
 
 ## Recent pyOpenSci Posts!

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -65,58 +65,13 @@ programs:
 
 ## Recently Accepted Python Packages
 
-
 <div class="grid">
     {% for apackage in site.data.packages %}
     {% if apackage.highlight %}
-    <div class="cards">
-    <article class="archive__item" itemscope="" itemtype="https://schema.org/CreativeWork">
-        <!-- <div class="archive__item-teaser">
-            <img src="" alt="">
-        </div> -->
-        <h3 class="card__title no_toc" itemprop="headline">
-            <!-- <a href="{{ apackage.link }}" rel="permalink"> -->
-            {{ apackage.package-name }}
-            <!-- </a> -->
-        </h3>
-        <p class="page__meta contributors">
-         <span><i class="fas fa-feather" aria-hidden="true"></i>
-         <!-- Commas in between authors -->
-         {% for aMaintainer in apackage.maintainer %}  
-         {{ aMaintainer }}{% if forloop.last == false %}, {% endif %}
-         {% endfor %}
-         </span>
-        </p>
-        <span class="narrow">
-        <p class="archive__item-excerpt narrow" itemprop="description">{{ apackage.description | markdownify }}
-        </p>
-        </span>
-        <!-- This would probably be cool as a list and use light text for each ?
-        In this case i wouldn't have the card be a link but maybe the hover highlights
-        the content in the card? And the hover state isn't a hand to suggest 
-          docs-url: 
-  citation-link: -->
-        <ul>
-          <li>
-            <a href="{{ apackage.link }}" rel="permalink"><i class="fab fa-github"></i> View Code </a>
-          </li>
-          {% if apackage.docs-url %}
-          <li>
-            <a href="{{ apackage.docs-url }}" rel="permalink"><i class="fas fa-book-open"></i> View Docs</a>
-          </li>
-          {% endif %}
-          {% if apackage.citation-link %}
-          <li>
-            <a href="{{ apackage.docs-url }}" rel="permalink"><i class="fas fa-bookmark fa-fw"></i> Cite</a>
-          </li>
-        {% endif %}
-        </ul>
-    </article>
-    </div>
+{% include package-grid.html  %}
     {% endif %}
     {% endfor %}
 </div>
-
 
 <br clear="both">
 

--- a/_pages/python-packages.md
+++ b/_pages/python-packages.md
@@ -19,59 +19,13 @@ redirect_from:
 
 ## Our accepted Python open source packages
 
-<!--TODO: This would be better as rows of 3 vs 4; also adjust font size in cards > -->
 The packages below have already been through our open peer review process and 
 are accepted as pyOpenSci packages.
 
-
 <div class="grid">
-    {% for apackage in site.data.packages %}
-    <div class="cards">
-    <article class="archive__item" itemscope="" itemtype="https://schema.org/CreativeWork">
-        <!-- <div class="archive__item-teaser">
-            <img src="" alt="">
-        </div> -->
-        <h3 class="card__title no_toc" itemprop="headline">
-            <!-- <a href="{{ apackage.link }}" rel="permalink"> -->
-            {{ apackage.package-name }}
-            <!-- </a> -->
-        </h3>
-        <p class="page__meta contributors">
-         <span><i class="fas fa-feather" aria-hidden="true"></i>
-         <!-- Commas in between authors -->
-         {% for aMaintainer in apackage.maintainer %}  
-         {{ aMaintainer }}{% if forloop.last == false %}, {% endif %}
-         {% endfor %}
-         </span>
-        </p>
-        <span class="narrow">
-        <p class="archive__item-excerpt narrow" itemprop="description">{{ apackage.description | markdownify }}
-        </p>
-        </span>
-        <!-- This would probably be cool as a list and use light text for each ?
-        In this case i wouldn't have the card be a link but maybe the hover highlights
-        the content in the card? And the hover state isn't a hand to suggest 
-          docs-url: 
-  citation-link: -->
-        <ul>
-          <li>
-            <a href="{{ apackage.link }}" rel="permalink"><i class="fab fa-github"></i> View Code </a>
-          </li>
-          {% if apackage.docs-url %}
-          <li>
-            <a href="{{ apackage.docs-url }}" rel="permalink"><i class="fas fa-book-open"></i> View Docs</a>
-          </li>
-          {% endif %}
-          {% if apackage.citation-link %}
-          <li>
-            <a href="{{ apackage.docs-url }}" rel="permalink"><i class="fas fa-bookmark fa-fw"></i> Cite</a>
-          </li>
-        {% endif %}
-        </ul>
-    </article>
-    </div>
-    {% endfor %}
+{% for apackage in site.data.packages %}
+  {% include package-grid.html  %}
+{% endfor %}
 </div>
-
 
 <br clear="both">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -552,6 +552,20 @@ drop shadow
   }
 }
 
+
+/* Blog grid styles*/
+
+.blog__grid .cards {
+  padding: 0 !important;
+
+  .card-excerpt{
+    font-size: .8em;
+  }
+  .card-title {
+
+  }
+}
+
 .grid__wrapper {
   display: flex;
 }
@@ -665,17 +679,38 @@ h2.clearall {
   filter: drop-shadow(5px 5px 4px #ccc);
 }
 
-// .drop-down-off {
-//   opacity: 0;
-// }
+/* Blog grid styles */
 
-// .drop-down-off .vis-opac {
-//   opacity: 1;
-// }
+.blog__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: 1fr;
+  grid-column-gap: 10px;
+  grid-row-gap: 30px;
+  margin-bottom: 20px;
 
-// .drop-down-on {
-//   opacity: 1;
-// }
+  h3.card-title {
+    font-size: 1.2em!important;
+    text-align: left;
+	  margin-top: 0;
+	  vertical-align: middle;
+  }
+
+  .card__bkg {
+    padding-top: 30px;
+
+  }
+  article {
+	display: contents;
+  }
+  a {
+	text-decoration: none;
+  }
+  p {
+	font-size: 1.2em!important;
+	font-weight: 400;
+  }
+}
 
 @charset "utf-8";
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin


### PR DESCRIPTION
This PR:

* Adds the editorial board back to the page - fixes the code
* Moves package grids to an include template for simpler code
* Adds recent packages and view all packages to peer review page 
* it also cleans up the blog grid and code in general. 