### PR TITLE
ADD: redirect for coc

### DIFF
--- a/_pages/redirects/coc-redirect.md
+++ b/_pages/redirects/coc-redirect.md
@@ -1,0 +1,8 @@
+---
+title: pyOpenSci Community Code of Conduct
+permalink: /peer-review-guide/about-peer-review/code-of-conduct.html
+redirect_to: https://www.pyopensci.org/governance/code-of-conduct.html
+---
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>


### PR DESCRIPTION
This pr adds a redirect for when we move the COC to governance from the peer review guide. 
addresses https://github.com/pyOpenSci/governance/issues/29 

This should not be merged until we merge a PR that removes the COC from the peer review guide (PR TBD)