### PR TITLE
Fix: redirect pages in new peer review guide layout

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -113,7 +113,7 @@
   twitter: "lindsey_jh"
   mastodon: 
   orcidid:
-  website: "http://lindseyjh.ca/"
+  website: "https://lindseyjh.ca/"
   contributor_type:
     #- contributor
   packages-submitted: [""]

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -7,7 +7,7 @@ main:
         icon: 
         url: "/about-peer-review/"
       - title: "Peer review guide"
-        url: "https://www.pyopensci.org/peer-review-guide/"
+        url: "https://www.pyopensci.org/software-peer-review/"
         icon: "fas fa-external-link-alt"
       - title: "Python package guide"
         url: "https://www.pyopensci.org/python-package-guide/"

--- a/_pages/about-peer-review.md
+++ b/_pages/about-peer-review.md
@@ -24,7 +24,7 @@ classes: wide
             <p>You're in the right place! Learn about the steps to submit a package
             for open peer review in our guidebook. </p>
           </div>  
-          <p><a href="https://www.pyopensci.org/peer-review-guide/software-peer-review-guide/author-guide.html" class="btn btn--inverse"><i class="fas fa-angle-right"></i> View our Author Guide </a></p>
+          <p><a href="https://www.pyopensci.org/software-peer-review/how-to/author-guide.html" class="btn btn--inverse"><i class="fas fa-angle-right"></i> View our Author Guide </a></p>
       </div>
     </div>
   </div>

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -12,7 +12,7 @@ header:
         - label: "Submit a Package"
           url: "https://github.com/pyOpenSci/software-review/issues"
         - label: "Read our Peer Review Guide"
-          url: "https://www.pyopensci.org/peer-review-guide/"
+          url: "https://www.pyopensci.org/software-peer-review/"
 mission:
   - excerpt: 'We build diverse community that supports free and open Python tools for processing scientific data. We also build technical skills needed to contribute to open source and that support open science. Join our global community.'
 programs:

--- a/_pages/redirects/peer-review-guide/about.md
+++ b/_pages/redirects/peer-review-guide/about.md
@@ -1,0 +1,9 @@
+---
+title: "pyopensci author guide redirect page"
+permalink: peer-review-guide/about-peer-review/intro.html
+redirect_to: https://www.pyopensci.org/software-peer-review/about/intro.html
+---
+
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/aims-scope.md
+++ b/_pages/redirects/peer-review-guide/aims-scope.md
@@ -1,0 +1,9 @@
+---
+title: "pyopensci author guide redirect page"
+permalink: /peer-review-guide/about-peer-review/about-peer-review/aims-and-scope.html
+redirect_to: https://www.pyopensci.org/software-peer-review/about/package-scope.html
+---
+
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/author-guide.md
+++ b/_pages/redirects/peer-review-guide/author-guide.md
@@ -1,0 +1,9 @@
+---
+title: "pyopensci author guide redirect page"
+permalink: /contributing-guide/open-source-software-submissions/author-guide/
+redirect_to: https://www.pyopensci.org/peer-review-guide/software-peer-review-guide/author-guide.html
+---
+
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/benefits.md
+++ b/_pages/redirects/peer-review-guide/benefits.md
@@ -1,0 +1,9 @@
+---
+title: "pyopensci author guide redirect page"
+permalink: /peer-review-guide/about-peer-review/review-benefits.html
+redirect_to: https://www.pyopensci.org/software-peer-review/about/benefits.html
+---
+
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/coc.md
+++ b/_pages/redirects/peer-review-guide/coc.md
@@ -1,0 +1,8 @@
+---
+title: "pyopensci redirect page"
+permalink: /peer-review-guide/about-peer-review/code-of-conduct.html
+redirect_to: https://www.pyopensci.org/software-peer-review/code_of_conduct.html
+---
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/guides/author-guide.md
+++ b/_pages/redirects/peer-review-guide/guides/author-guide.md
@@ -1,0 +1,9 @@
+---
+title: "pyopensci redirect page"
+permalink: /peer-review-guide/software-peer-review-guide/author-guide.html
+redirect_to: https://www.pyopensci.org/software-peer-review/how-to/author-guide.html
+---
+
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/guides/editor-guide.md
+++ b/_pages/redirects/peer-review-guide/guides/editor-guide.md
@@ -1,0 +1,9 @@
+---
+title: "pyopensci redirect page"
+permalink: /peer-review-guide/software-peer-review-guide/editor-guide.html
+redirect_to: https://www.pyopensci.org/software-peer-review/how-to/editor-guide.html
+---
+
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/guides/editor-in-chief-guide.md
+++ b/_pages/redirects/peer-review-guide/guides/editor-in-chief-guide.md
@@ -1,0 +1,9 @@
+---
+title: "pyopensci redirect page"
+permalink: /peer-review-guide/software-peer-review-guide/editor-in-chief-guide.html
+redirect_to: https://www.pyopensci.org/software-peer-review/how-to/editor-in-chief-guide.html
+---
+
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/guides/onboarding-guide.md
+++ b/_pages/redirects/peer-review-guide/guides/onboarding-guide.md
@@ -1,0 +1,9 @@
+---
+title: "pyopensci redirect page"
+permalink: /peer-review-guide/software-peer-review-guide/onboarding-guide.html
+redirect_to: https://www.pyopensci.org/software-peer-review/how-to/onboarding-guide.html
+---
+
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/guides/reviewer-guide.md
+++ b/_pages/redirects/peer-review-guide/guides/reviewer-guide.md
@@ -1,0 +1,9 @@
+---
+title: "pyopensci redirect page"
+permalink: /peer-review-guide/software-peer-review-guide/reviewer-guide.html
+redirect_to: https://www.pyopensci.org/software-peer-review/how-to/reviewer-guide.html
+---
+
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/guides/timeline.md
+++ b/_pages/redirects/peer-review-guide/guides/timeline.md
@@ -1,0 +1,9 @@
+---
+title: "pyopensci redirect page"
+permalink: /peer-review-guide/software-peer-review-guide/intro.html
+redirect_to: https://www.pyopensci.org/software-peer-review/our-process/review-timeline.html
+---
+
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/guides/where-to-find-reviewers.md
+++ b/_pages/redirects/peer-review-guide/guides/where-to-find-reviewers.md
@@ -1,0 +1,9 @@
+---
+title: "pyopensci redirect page"
+permalink: /peer-review-guide/software-peer-review-guide/where-to-find-python-package-reviewers.html
+redirect_to: https://www.pyopensci.org/software-peer-review/how-to/finding-reviewers.html
+---
+
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/how-review-works.md
+++ b/_pages/redirects/peer-review-guide/how-review-works.md
@@ -1,0 +1,9 @@
+---
+title: "pyopensci how review works redirect page"
+permalink: /peer-review-guide/about-peer-review/how-peer-review-works.html
+redirect_to: https://www.pyopensci.org/software-peer-review/our-process/how-review-works.html
+---
+
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/peer-review-guide.md
+++ b/_pages/redirects/peer-review-guide/peer-review-guide.md
@@ -1,0 +1,8 @@
+---
+title: "pyopensci peer review guide redirect page"
+permalink: /peer-review-guide/
+redirect_to: https://www.pyopensci.org/software-peer-review
+---
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/policies.md
+++ b/_pages/redirects/peer-review-guide/policies.md
@@ -1,0 +1,8 @@
+---
+title: "pyopensci redirect page"
+permalink: /peer-review-guide/about-peer-review/policies-guidelines.html
+redirect_to: https://www.pyopensci.org/software-peer-review/our-process/policies.html
+---
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/pyos-joss.md
+++ b/_pages/redirects/peer-review-guide/pyos-joss.md
@@ -1,0 +1,8 @@
+---
+title: "pyopensci redirect page"
+permalink: /peer-review-guide/about-peer-review/pyopensci-related-joss-ropensci.html
+redirect_to: https://www.pyopensci.org/software-peer-review/partners/joss.html
+---
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/why-open-review.md
+++ b/_pages/redirects/peer-review-guide/why-open-review.md
@@ -3,3 +3,6 @@ title: "pyopensci author guide redirect page"
 permalink: /contributing-guide/open-source-software-submissions/author-guide/
 redirect_to: https://www.pyopensci.org/peer-review-guide/software-peer-review-guide/author-guide.html
 ---
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you 
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -12,7 +12,7 @@ governance. The guidebook links below are being updated and we welcome feedback!
 
 * [**pyOpenSci Github Organization**](https://github.com/pyOpenSci): Contains our [software-review](https://github.com/pyOpenSci/software-review) repo that hosts the peer-review process. Also contains our guidebook, cookiecutter, and governance repos (see below).
 
-* [**pyOpenSci Peer Review**](https://www.pyopensci.org/peer-review-guide/): Contains information for package authors and reviewers.
+* [**pyOpenSci Peer Review**](https://www.pyopensci.org/software-peer-review/): Contains information for package authors and reviewers.
 
 * [**pyOpenSci's Governance**](https://www.pyopensci.org/governance/): Where we discuss the direction and scope of pyOpenSci. We're a community organization, so please feel free to create an [issue](https://github.com/pyOpenSci/governance/issues) if you have any questions or concerns!
 

--- a/_posts/2022-09-10-executive-director-pyopensci-leah-wasser-updates.md
+++ b/_posts/2022-09-10-executive-director-pyopensci-leah-wasser-updates.md
@@ -101,7 +101,7 @@ There are a few ways to get involved with us now.
 1. [You can sign up to be a reviewer by filling out our reviewer form](https://forms.gle/B6zAukLCvJot5nws6). If you do this, we will reach out to you if a package is submitted that suits your background and interests!
   * We will also be growing our editorial board in the upcoming months. Once you have reviewed for us you are eligible to be considered as an editor. We will be posting more about this process in the upcoming months.
 1. Our open peer review process is running! If you have a package that you are working on, [you can submit it to our peer review process](https://github.com/pyOpenSci/software-review/issues). 
-  * You can learn more about our review process here in our [community guide (which will be updated in the upcoming months so that it is more clear)](https://www.pyopensci.org/peer-review-guide/about-peer-review/aims-and-scope.html).
+  * You can learn more about our review process here in our [community guide (which will be updated in the upcoming months so that it is more clear)](https://www.pyopensci.org/software-peer-review/software-peer-review/about/package-scope.html).
   * If you have a package that you wish to submit but need some guidance, you can also submit a presubmission inquiry or a request for help here.
 2. You can [follow us on twitter](https://www.twitter.com/pyopensci) to keep tabs on our progress. 
 

--- a/_posts/2022-09-27-call-for-python-software-review-editors.md
+++ b/_posts/2022-09-27-call-for-python-software-review-editors.md
@@ -18,7 +18,7 @@ comments: true
 ## An update on pyOpenSci's review process 
 
 Hey there! I just wanted to update everyone about where pyOpenSci is with 
-its peer review process. We are currently hard at work updating [our peer review guides](https://www.pyopensci.org/peer-review-guide/) to 
+its peer review process. We are currently hard at work updating [our peer review guides](https://www.pyopensci.org/software-peer-review/) to 
 streamline the peer review process. For the next 2 months (October & November 2022) 
 we will prioritize setting up an editorial board to support new reviews as they 
 come in. 
@@ -29,7 +29,7 @@ With that below you will find a few updates.
 
 [David Nicholson](https://github.com/NickleDave), who has been working with pyOpenSci for the past few years as 
 an editor will take on the Editor in Chief role! [You can learn more about that 
-role here](https://www.pyopensci.org/peer-review-guide/software-peer-review-guide/editor-in-chief-guide.html) in our peer review guide. This position will rotate once we have our editorial board setup.
+role here](https://www.pyopensci.org/software-peer-review/how-to/editor-in-chief-guide.html) in our peer review guide. This position will rotate once we have our editorial board setup.
 
 As Editor in Chief, David will:
 
@@ -58,7 +58,7 @@ longer given mutual consent. You will be responsible for handling 3-4 package
 reviews during that year. We may also bring on guest editors in other 
 instances, e.g., because of their familiarity with a specific domain.
 
-You can read more about the [roles and responsibilities of and editor here](https://www.pyopensci.org/peer-review-guide/software-peer-review-guide/editors-guide.html). 
+You can read more about the [roles and responsibilities of an editor here](https://www.pyopensci.org/software-peer-review/how-to/editor-guide.html). 
 
 We currently have a package in the queue that is spatial / remote sensing related
 that we'd love to have an editor onboard to review. But we are in need of editors

--- a/_posts/2022-10-24-why-should-python-open-source-matter-science.md
+++ b/_posts/2022-10-24-why-should-python-open-source-matter-science.md
@@ -208,7 +208,7 @@ So how do we track open source tool health (for science)?
 
 ### Peer review is actually the second step in our process. 
 
-We won't begin to review a package [without bare minimum checks](https://www.pyopensci.org/peer-review-guide/software-peer-review-guide/author-guide.html#does-your-package-meet-packaging-requirements).
+We won't begin to review a package [without bare minimum checks](https://www.pyopensci.org/software-peer-review/how-to/author-guide.html#does-your-package-meet-packaging-requirements).
 We hope that these bare minimal checks help maintainers as they try to decide
 what is good enough infrastructure for their package. 
 

--- a/_posts/2022-11-21-what-makes-a-python-package-healthy.md
+++ b/_posts/2022-11-21-what-makes-a-python-package-healthy.md
@@ -210,7 +210,7 @@ Ivan was quick to point out some basic metrics offered by GitHub which follow th
 
 <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Maybe not totally related, but github has a section called community standards that mabe could be used as reference, for example: <a href="https://t.co/wmu1bDdcQR">https://t.co/wmu1bDdcQR</a></p>&mdash; XMN (@xmnlab) <a href="https://twitter.com/xmnlab/status/1578745372880429057?ref_src=twsrc%5Etfw">October 8, 2022</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 
 
-Actually it's totally related, Ivan! Let's have a look look at the [pyOpenSci contributing-guide GitHub repository](https://www.github.com/pyopensci/peer-review-guide/community) to see how we are 
+Actually it's totally related, Ivan! Let's have a look look at the [pyOpenSci contributing-guide GitHub repository](https://www.github.com/pyopensci/software-peer-review/community) to see how we are 
 doing as an organization.
 
 Note that we are missing some important components:


### PR DESCRIPTION
This PR can be merged once the peer review revamp / reorg is merged. it simply provide redirects for every page in the guide given the new url change.

steps

1. rename repo (drop guide
2. [merge PR ](https://github.com/pyOpenSci/peer-review-guide/pull/154)

Once merged immediate merge this. By the time all of the actions run the redirects should be soundly in place. but this all needs to happen at the same time. 

## Ci failure points

* 404s because the redirect pages don't exist yet (expected)
- [x] two blog urls that i can just fix here as well. 

related
https://github.com/pyOpenSci/peer-review-guide/pull/154