### PR TITLE
Add: new contributors to website

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -33,6 +33,7 @@
   github_image_id: 889238
   title: Board chair
   board: true
+  website:
   location:
   email: tkteal@gmail.com
 - name: Karen Cranston
@@ -101,7 +102,7 @@
   twitter: xmnlab
   mastodon:
   orcidid: 0000-0001-5049-4289
-  website: https://xmnlab.github.io
+  website:
   editor:
   contributor_type:
     - reviewer
@@ -183,7 +184,7 @@
   twitter:
   mastodon: https://hachyderm.io/@yuvipanda
   orcidid:
-  website: https://words.yuvi.in
+  website:
   contributor_type: []
   packages-submitted:
     -
@@ -406,6 +407,7 @@
   packages-editor:
     -
   twitter: dynamicwebpaige
+  website:
   location: Seattle, WA
   email: paige.bailey@alumni.rice.edu
 - name: Carson Farmer
@@ -456,6 +458,7 @@
   packages-editor:
     -
   twitter:
+  website:
   location:
   email: kysolvik@gmail.com
 - name: Martin Skarzynski
@@ -492,6 +495,7 @@
   packages-editor:
     -
   twitter:
+  website:
   location: Washington, DC
   email: triznam@si.edu
 - name: Neil Chue Hong
@@ -579,6 +583,7 @@
   packages-editor:
     -
   twitter: metasomite
+  website:
   location: Perth, WA, Australia
   email:
 - name: Philip Meier
@@ -596,6 +601,7 @@
   packages-editor:
     -
   twitter:
+  website:
   location: Germany
   email:
 - name: Edgar Riba
@@ -613,6 +619,7 @@
   packages-editor:
     -
   twitter: edgarriba
+  website:
   location: Barcelona, Spain
   email: edgar.riba@gmail.com
 - name: DOV-Vlaanderen
@@ -663,6 +670,7 @@
   packages-editor:
     -
   twitter:
+  website:
   location:
   email:
 - name: Pieter Jan Haest
@@ -713,6 +721,7 @@
   packages-editor:
     -
   twitter: ksielemann
+  website:
   location:
   email:
 - name: Moritz Lürig
@@ -785,6 +794,7 @@
   packages-editor:
     -
   twitter:
+  website:
   location: Missoula, MT
   email: endsley@umich.edu
 - name: Alejandro Sáez Mollejo
@@ -803,6 +813,7 @@
   packages-editor:
     -
   twitter:
+  website:
   location: Madrid (Spain)
   email: alex.saez.12@gmail.com
 - name: Julius Busecke
@@ -819,6 +830,7 @@
   packages-editor:
     -
   twitter: JuliusBusecke
+  website:
   location: Brooklyn, New York
   email:
 - name: Szymon Moliński
@@ -873,7 +885,7 @@
     - doc
     - design
   github_username: tupui
-  website: https://github.com/tupui
+  website:
   github_image_id: 23188539
   mastodon:
   twitter: PamphileRoy
@@ -907,7 +919,7 @@
     - code
     - review
   github_username: radoering
-  website: https://github.com/radoering
+  website:
   github_image_id: 30527984
   mastodon:
   twitter:
@@ -925,7 +937,7 @@
     - design
     - review
   github_username: astrojuanlu
-  website: https://social.juanlu.space/@astrojuanlu
+  website:
   github_image_id: 316517
   mastodon:
   twitter:
@@ -982,7 +994,7 @@
     - design
     - review
   github_username: eli-schwartz
-  website: https://github.com/eli-schwartz
+  website:
   github_image_id: 6551424
   mastodon:
   twitter:
@@ -1131,7 +1143,7 @@
     - review
     - code
   github_username: matthew-brett
-  website: https://matthew.dynevor.org
+  website:
   github_image_id: 67612
   mastodon:
   twitter:
@@ -1148,7 +1160,7 @@
     - review
     - code
   github_username: ReventonC
-  website: http://zehuachen.com
+  website:
   github_image_id: 6276623
   mastodon:
   twitter:
@@ -1165,7 +1177,7 @@
     - code
     - review
   github_username: sumit-158
-  website: https://github.com/sumit-158
+  website:
   github_image_id: 96618001
   mastodon:
   twitter: itss_sumit
@@ -1182,7 +1194,7 @@
     - review
     - code
   github_username: consideRatio
-  website: https://github.com/consideRatio
+  website:
   github_image_id: 3837114
   mastodon:
   twitter: e_Sundell

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -8,7 +8,7 @@
   twitter: leahawasser
   mastodon: https://fosstodon.org/@leahawasser
   orcidid: 0000-0002-8177-6550
-  website: www.leahwasser.com
+  website: https://www.leahwasser.com
   board: true
   contributor_type:
     - leadership
@@ -60,7 +60,7 @@
   twitter: choldgraf
   mastodon: https://hachyderm.io/@choldgraf
   orcidid: 0000-0002-2391-0678
-  website: chrisholdgraf.com
+  website: https://chrisholdgraf.com
   contributor_type:
   packages-submitted:
     -
@@ -124,7 +124,7 @@
   github_image_id: 950575
   twitter: ocefpaf
   orcidid: 0000-0003-4165-2913
-  website: http://ocefpaf.github.io/python4oceanographers
+  website: https://ocefpaf.github.io/python4oceanographers
   contributor_type:
   packages-submitted:
     - errdapy
@@ -145,7 +145,7 @@
   twitter: lindsey_jh
   mastodon:
   orcidid:
-  website: http://lindseyjh.ca/
+  website: https://lindseyjh.ca/
   contributor_type:
   packages-submitted:
     -
@@ -166,7 +166,7 @@
   twitter: martinfleis
   mastodon: https://fosstodon.org/@martinfleis
   orcidid: 0000-0003-3319-3366
-  website: martinfleischmann.net
+  website: https://martinfleischmann.net
   contributor_type:
     - reviewer
   packages-submitted:
@@ -202,7 +202,7 @@
   twitter: arianemsasso
   mastodon:
   orcidid:
-  website: arianesasso.me
+  website: https://arianesasso.me
   contributor_type:
     - package-maintainer
     - editor
@@ -272,7 +272,7 @@
   twitter:
   mastodon:
   orcidid:
-  website: linkedin.com/in/jennypalomino
+  website: https://linkedin.com/in/jennypalomino
   contributor_type:
     - reviewer
     - contributor
@@ -300,7 +300,7 @@
   github_image_id: 590385
   mastodon:
   orcidid:
-  website: http://anitagraser.com
+  website: https://anitagraser.com
   contributor_type:
     - package-maintainer
   packages-submitted:
@@ -324,7 +324,7 @@
   github_image_id: 11004857
   mastodon: https://fosstodon.org/@batalex
   orcidid:
-  website: batalex.github.io
+  website: https://batalex.github.io
   contributor_type:
     - editor
     - reviewer
@@ -346,7 +346,7 @@
   twitter: choldgraf
   mastodon:
   orcidid:
-  website: chrisholdgraf.com
+  website: https://chrisholdgraf.com
   contributor_type:
     - leadership
     - editor
@@ -407,7 +407,7 @@
   packages-editor:
     -
   twitter: dynamicwebpaige
-  website: http://paigevie.ws
+  website: https://paigevie.ws
   location: Seattle, WA
   email: paige.bailey@alumni.rice.edu
 - name: Carson Farmer
@@ -424,7 +424,7 @@
   packages-editor:
     -
   twitter: carsonfarmer
-  website: http://carsonfarmer.com
+  website: https://carsonfarmer.com
   location: Victoria, B.C., Canada
   email: carson.farmer@gmail.com
 - name: Joe Hamman
@@ -441,7 +441,7 @@
   packages-editor:
     -
   twitter: _jhamman
-  website: http://joehamman.com
+  website: https://joehamman.com
   location: Seattle, WA
   email: jhamman1@gmail.com
 - name: Kylen Solvik
@@ -514,7 +514,7 @@
   packages-editor:
     -
   twitter:
-  website: http://www.software.ac.uk
+  website: https://www.software.ac.uk
   location: Edinburgh, United Kingdom
   email:
 - name: Niels Bantilan
@@ -532,7 +532,7 @@
   packages-editor:
     -
   twitter: cosmicbboy
-  website: http://cosmicbboy.github.io/
+  website: https://cosmicbboy.github.io/
   location: Atlanta, GA, US
   email: niels.bantilan@gmail.com
 - name: Sean Gillies
@@ -619,7 +619,7 @@
   packages-editor:
     -
   twitter: edgarriba
-  website: www.kornia.org
+  website: https://www.kornia.org
   location: Barcelona, Spain
   email: edgar.riba@gmail.com
 - name: DOV-Vlaanderen
@@ -704,7 +704,7 @@
   packages-editor:
     -
   twitter: Jonny_Wireless
-  website: jonny.bio
+  website: https://jonny.bio
   location:
   email:
 - name: Katharina Sielemann
@@ -741,7 +741,7 @@
   packages-editor:
     -
   twitter: mluerig
-  website: www.luerig.net
+  website: https://www.luerig.net
   location: Sweden
   email: moritz.luerig@gmail.com
 - name: Emily Jane McTavish
@@ -759,7 +759,7 @@
   packages-editor:
     -
   twitter:
-  website: McTavishLab.github.io
+  website: https://McTavishLab.github.io
   location:
   email: ejmctavish@ucmerced.edu
 - name: Luna L. Sanchez Reyes
@@ -777,7 +777,7 @@
   packages-editor:
     -
   twitter: LunaSare
-  website: www.lunasare.com
+  website: https://www.lunasare.com
   location: Merced, CA, USA
   email: sanchez.reyes.luna@gmail.com
 - name: K. Arthur Endsley
@@ -794,7 +794,7 @@
   packages-editor:
     -
   twitter:
-  website: http://karthur.org/
+  website: https://karthur.org/
   location: Missoula, MT
   email: endsley@umich.edu
 - name: Alejandro Sáez Mollejo
@@ -830,7 +830,7 @@
   packages-editor:
     -
   twitter: JuliusBusecke
-  website: http://www.juliusbusecke.com
+  website: https://www.juliusbusecke.com
   location: Brooklyn, New York
   email:
 - name: Szymon Moliński
@@ -847,7 +847,7 @@
   packages-editor:
     -
   twitter:
-  website: ml-gis-service.com
+  website: https://ml-gis-service.com
   location:
   email: simon@ml-gis-service.com
 - name: Nicolas Palopoli
@@ -859,7 +859,7 @@
   twitter:
   mastodon: https://fediscience.org/@npalopoli
   orcidid: ​0000-0001-7925-6436
-  website: http://about.me/npalopoli
+  website: https://about.me/npalopoli
   location: Buenos Aires, Argentina
   email: nicopalo@gmail.com
 - name: Erik Welch
@@ -955,7 +955,7 @@
     - design
     - review
   github_username: henryiii
-  website: iscinumpy.dev
+  website: https://iscinumpy.dev
   github_image_id: 4616906
   mastodon:
   twitter: henryschreiner3
@@ -1160,7 +1160,7 @@
     - review
     - code
   github_username: ReventonC
-  website: zehuachen.com
+  website: https://zehuachen.com
   github_image_id: 6276623
   mastodon:
   twitter:
@@ -1213,7 +1213,7 @@
     - review
     - code
   github_username: arokem
-  website: http://arokem.org
+  website: https://arokem.org
   github_image_id: 118582
   mastodon:
   twitter:
@@ -1230,7 +1230,7 @@
     - review
     - code
   github_username: jmason86
-  website: jamespaulmason.com
+  website: https://jamespaulmason.com
   github_image_id: 947614
   mastodon:
   twitter: starfleetjames

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -1,64 +1,82 @@
-# Staff goes here
-- name: "Leah Wasser"
+- name: Leah Wasser
   sort: 1
-  bio: "Executive Director, pyOpenSci"
-  organization: "pyOpenSci"
-  github_username: "lwasser"
-  github_image_id: 7649194 # You can find this by right clicking on the image in your bio, and copying the link. the last part contains a 7 digit number that is your avatar image!
-  title: "Executive Director"
-  twitter: "leahawasser"
-  mastodon: "https://fosstodon.org/@leahawasser"
+  bio: "Open education, Open source and Open Science.\r\nExecutive Director @pyOpenSci "
+  organization: pyOpenSci
+  github_username: lwasser
+  github_image_id: 7649194
+  title: Executive Director
+  twitter: leahawasser
+  mastodon: https://fosstodon.org/@leahawasser
   orcidid: 0000-0002-8177-6550
-  website: "https://www.leahwasser.com"
+  website: www.leahwasser.com
   board: true
   contributor_type:
     - leadership
     - current editor
     - package-maintainer
-  packages-editor: ["errdapy", "pandera", "nbless"]
-  packages-submitted: ["earthpy"]
-  packages-reviewed: [""]
+  packages-editor:
+    - errdapy
+    - pandera
+    - nbless
+  packages-submitted:
+    - earthpy
+  packages-reviewed:
+    -
+  location: United States
+  email: leah@pyopensci.org
 - name: Tracy Teal
   sort: 2
-  bio: ''
-  organization: "RStudio"
-  twitter: "tracykteal"
-  github_username: "tracykteal"
-  github_image_id: 889238 # You can find this by right clicking on the image in your bio, and copying the link. the last part contains a 7 digit number that is your avatar image!
-  title: "Board chair"
+  bio:
+  organization:
+  twitter:
+  github_username: tracykteal
+  github_image_id: 889238
+  title: Board chair
   board: true
-- name: "Karen Cranston"
+  website:
+  location:
+  email: tkteal@gmail.com
+- name: Karen Cranston
   sort: 3
-  title: ""
-  bio: ''
-  organization: ""
+  title:
+  bio:
+  organization:
   twitter: kcranstn
   mastodon:
   orcidid:
-  website:
+  website: https://karencranston.ca/
   github_username: kcranston
   github_image_id: 312034
   board: true
-## Advisory council
-- name: "Chris Holdgraf"
+  location: Ottawa, ON
+  email: karen.cranston@gmail.com
+- name: Chris Holdgraf
   advisory: true
-  bio: "Executive Director, 2i2c"
-  organization: "2i2c, Project Jupyter"
-  github_username: "choldgraf"
+  bio: I work with Project Jupyter and other open communities to build tools and
+    solve problems for scientific research and education.
+  organization: UC Berkeley
+  github_username: choldgraf
   github_image_id: 1839645
-  twitter: "choldgraf"
-  mastodon: "https://hachyderm.io/@choldgraf"
-  orcidid: "0000-0002-2391-0678"
-  website: "https://chrisholdgraf.com"
+  twitter: choldgraf
+  mastodon: https://hachyderm.io/@choldgraf
+  orcidid: 0000-0002-2391-0678
+  website: chrisholdgraf.com
   contributor_type:
-    #- contributor
-  packages-submitted: [""]
-  packages-reviewed: ["erdapy"]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    - erdapy
+  packages-editor:
+    -
+  location: California
+  email:
 - name: Leonardo Uieda
   advisory: true
-  bio: ''
-  organization: "University of Liverpool, JOSS"
+  bio:
+    Lecturer in Geophysics @compgeolab University of Liverpool. I study and teach
+    the solid Earth, from global to micro scale, using Python and open-source
+    tools
+  organization: University of Liverpool
   github_username: leouieda
   github_image_id: 290082
   twitter:
@@ -66,110 +84,144 @@
   orcidid:
   website: https://www.leouieda.com
   contributor_type:
-    #- contributor
-  packages-submitted: [""]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  location: Liverpool, UK
+  email: Leonardo.Uieda@liverpool.ac.uk
 - name: Ivan Ogasawara
   sort: 1
   advisory: true
-  bio: 'I had the opportunity to develop in multiple programming languages, such as Python, C++, Javascript, PHP, VB, JAVA, ShellScript for back-end, front-end, besides promoting DevOps and packaging'
-  organization: "Open Science Labs, ArxLang"
+  bio: Open Source Developer
+  organization: xmnlab
   github_username: xmnlab
   github_image_id: 5209757
-  twitter: "xmnlab"
+  twitter: xmnlab
   mastodon:
   orcidid: 0000-0001-5049-4289
-  website: "https://xmnlab.github.io"
-  #title: "Alumni Editor"
-  editor: #true # can say emeritus when they step down?
+  website:
+  editor:
   contributor_type:
     - reviewer
     - alumni-editor
-  packages-submitted: [""]
-  packages-reviewed: ["pandera"]
-  packages-editor: ["sevivi"]
+  packages-submitted:
+    -
+  packages-reviewed:
+    - pandera
+  packages-editor:
+    - sevivi
+  location: Earth
+  email: ivan.ogasawara@gmail.com
 - name: Filipe Fernandes
   advisory: true
-  bio: 'Physical Oceanographer'
-  organization: "IOOS, Conda-Forge"
+  bio: Filipe Fernandes is a Physical oceanographer by training, turned research
+    software engineer, and a software packager hobbyist.
+  organization:
   github_username: ocefpaf
   github_image_id: 950575
   twitter: ocefpaf
-  # mastodon: "https://scicomm.xyz/@ocefpaf"
   orcidid: 0000-0003-4165-2913
-  website:
+  website: http://ocefpaf.github.io/python4oceanographers
   contributor_type:
-    #- contributor #commented out because has an advisory role
-  packages-submitted: ["errdapy"]
-  packages-reviewed: [""]
-  packages-editor: [""]
-- name: "Lindsey Heagy"
+  packages-submitted:
+    - errdapy
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  location: Florianópolis, SC
+  email: ocefpaf@gmail.com
+- name: Lindsey Heagy
   advisory: true
-  bio: 'Assistant Professor'
-  organization: "UBC EOAS"
-  github_username: "lheagy"
+  bio:
+    "Asst. Prof at UBC EOAS. Researcher working on geophysical simulations and\
+    \ inversions (in @simpeg!) and data science.\r\n"
+  organization: "@simpeg, @geoscixyz, @ubcgif, @2i2c_org "
+  github_username: lheagy
   github_image_id: 6361812
-  twitter: "lindsey_jh"
-  mastodon: 
+  twitter: lindsey_jh
+  mastodon:
   orcidid:
-  website: "https://lindseyjh.ca/"
+  website: http://lindseyjh.ca/
   contributor_type:
-    #- contributor
-  packages-submitted: [""]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  location:
+  email: lheagy@eos.ubc.ca
 - name: Martin Fleischmann
   advisory: true
-  bio: 'Urban Data Scientist'
-  organization: "Charles University in Prague, University of Liverpool"
+  bio:
+    Researcher in geographic data science. Member of @geopandas and @pysal development
+    teams.
+  organization:
   github_username: martinfleis
   github_image_id: 36797143
   twitter: martinfleis
-  mastodon: "https://fosstodon.org/@martinfleis"
+  mastodon: https://fosstodon.org/@martinfleis
   orcidid: 0000-0003-3319-3366
-  website:
+  website: martinfleischmann.net
   contributor_type:
     - reviewer
-  packages-submitted: [""]
-  packages-reviewed: ["movingpandas"]
+  packages-submitted:
+    -
+  packages-reviewed:
+    - movingpandas
+  location: Prague
+  email: martin@martinfleischmann.net
 - name: Yuvi Panda
   advisory: true
-  bio: 'Open Source Infrastructure Engineer'
-  organization: "Project Jupyter"
+  bio:
+  organization:
   github_username: yuvipanda
   github_image_id: 30430
-  twitter: 
+  twitter:
   mastodon: https://hachyderm.io/@yuvipanda
-  orcidid: 
-  website: https://words.yuvi.in
+  orcidid:
+  website:
   contributor_type: []
-  packages-submitted: [""]
-  packages-reviewed: [""]
-# Editors
+  packages-submitted:
+    -
+  packages-reviewed:
+    -
+  location:
+  email:
 - name: Ariane Sasso
-  bio: 'Researcher in Medical Informatics and Digital Health'
-  organization: "Hasso Plattner Institute"
-  title: "Editor"
+  bio: Researcher in Medical Informatics and Digital Health ⌚ 👩‍💻 🧬
+  organization: "@hpi-dhc"
+  title: Editor
   github_username: arianesasso
   github_image_id: 3659681
   editorial-board: true
-  twitter:
+  twitter: arianemsasso
   mastodon:
   orcidid:
-  website:
+  website: arianesasso.me
   contributor_type:
     - package-maintainer
     - editor
-  packages-editor: ["pyteny"]
-  packages-submitted: ["devicely"]
-  packages-reviewed: [""]
+  packages-editor:
+    - pyteny
+  packages-submitted:
+    - devicely
+  packages-reviewed:
+    -
+  location: Berlin, Germany
+  email: ariane.sasso@gmail.com
 - name: David Nicholson
   sort: 2
-  title: "Editor in Chief"
+  title: Editor in Chief
   editorial-board: true
-  bio: 'Bio goes here just a sentence or two is great!'
-  organization: ""
+  bio:
+    ML, AI; behavior + cog + neuro. Open + inclusive science. Pythonista. He/him/they/them.
+    Habla espanglish y baila salsa y bachata a medio tiempo.
+  organization:
   github_username: NickleDave
   github_image_id: 11934090
   twitter: nicholdav
@@ -179,389 +231,1016 @@
   contributor_type:
     - current editor
     - contributor
-  packages-submitted: [""]
-  packages-reviewed: ["pydov"]
-  packages-editor: ["openomics", "physcraper", "pystiche"]
+  packages-submitted:
+    -
+  packages-reviewed:
+    - pydov
+  packages-editor:
+    - openomics
+    - physcraper
+    - pystiche
+  location: Charm City
+  email:
 - name: Chiara Marmo
-  bio: 'Research Software Engineer, geospatial, planetary and astronomy data.'
-  organization: ""
-  title: "Editor"
+  bio:
+  organization:
+  title: Editor
   github_username: cmarmo
   github_image_id: 1662261
   editorial-board: true
   twitter:
   mastodon:
   orcidid: 0000-0003-2843-6044
-  website: https://cmarmo.github.io
+  website: https://orcid.org/0000-0003-2843-6044
   contributor_type:
     - editor
-  packages-editor: ["crowsetta"]
-  packages-submitted: [""]
-  packages-reviewed: [""]
+  packages-editor:
+    - crowsetta
+  packages-submitted:
+    -
+  packages-reviewed:
+    -
+  location:
+  email:
 - name: Jenny Palomino
-  bio: 'Technical Curriculum Developer for Data Engineering'
-  title: "Editor"
-  organization: "Google Cloud Learning Services"
+  bio: Technical Curriculum Developer, Data Engineering
+  title: Editor
+  organization: Google
   github_username: jlpalomino
   github_image_id: 4017492
   editorial-board: true
   twitter:
   mastodon:
   orcidid:
-  website:
+  website: linkedin.com/in/jennypalomino
   contributor_type:
     - reviewer
     - contributor
-  focus-areas: ["gis", "spatial-remote-sensing", "database"]
-  packages-editor: [""]
-  packages-submitted: ["earthpy"]
-  packages-reviewed: ["erddapy"]
+  focus-areas:
+    - gis
+    - spatial-remote-sensing
+    - database
+  packages-editor:
+    -
+  packages-submitted:
+    - earthpy
+  packages-reviewed:
+    - erddapy
+  location:
+  email:
 - name: Anita Graser
-  bio: 'Researcher, open source GIS developer and author.'
-  organization: "AIT Austrian Institute of Technology"
-  title: "Editor"
+  bio: "Spatial data science with a focus on mobility & data quality "
+  organization:
+  title: Editor
   editorial-board: true
-  focus-areas: ["gis", "spatial-vector-data"]
+  focus-areas:
+    - gis
+    - spatial-vector-data
   github_username: anitagraser
   github_image_id: 590385
   mastodon:
   orcidid:
-  website:
+  website: http://anitagraser.com
   contributor_type:
     - package-maintainer
-  packages-submitted: ["movingpandas"]
-  packages-reviewed: [""]
-  packages-editor: [""]
-  twitter: "underdarkGIS"
+  packages-submitted:
+    - movingpandas
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter: underdarkGIS
+  location:
+  email:
 - name: Alex Batisse
-  bio: "Software engineer & Data scientist."
+  bio:
   organization:
-  title: "Editor"
+  title: Editor
   editorial-board: true
-  focus-areas: ["analytics", "data visualization"]
+  focus-areas:
+    - analytics
+    - data visualization
   github_username: batalex
   github_image_id: 11004857
   mastodon: https://fosstodon.org/@batalex
   orcidid:
-  website: https://batalex.github.io/
+  website: batalex.github.io
   contributor_type:
     - editor
     - reviewer
-  packages-submitted: [""]
-  packages-reviewed: ["Pynteny"]
-  packages-editor: ["Xclim"]
+  packages-submitted:
+    -
+  packages-reviewed:
+    - Pynteny
+  packages-editor:
+    - Xclim
   twitter:
-# Reviewers & maintainers go here
+  location:
+  email: alexandre.batisse@hey.com
 - name: Chris Holdgraf
-  bio: 'Bio Here'
-  organization: "Berkeley Bids, Project Jupyter, Binder"
+  bio: I work with Project Jupyter and other open communities to build tools and
+    solve problems for scientific research and education.
+  organization: UC Berkeley
   github_username: choldgraf
   github_image_id: 1839645
-  twitter:
+  twitter: choldgraf
   mastodon:
   orcidid:
-  website:
+  website: chrisholdgraf.com
   contributor_type:
     - leadership
     - editor
     - reviewer
-  packages-submitted: [""]
-  packages-reviewed: ["erdapy"]
+  packages-submitted:
+    -
+  packages-reviewed:
+    - erdapy
+  location: California
+  email:
 - name: Max Joseph
-  bio: 'Data Scientist'
-  organization: "Earth Lab, University of Colorado - Boulder"
+  bio: Data scientist doing Bayesian stats & machine learning
+  organization: "@SilviaTerra"
   github_username: mbjoseph
   github_image_id: 2664564
-  twitter:
+  twitter: mxwlj
   mastodon:
   orcidid:
-  website:
+  website: https://mbjoseph.github.io
   contributor_type:
     - reviewer
-  packages-submitted: [""]
-  packages-reviewed: ["pandera"]
+  packages-submitted:
+    -
+  packages-reviewed:
+    - pandera
+  location: Denver, CO
+  email: maxwellbjoseph@gmail.com
 - name: Luiz Irber
-  bio: ''
-  organization: "DIB Lab -- UC Davis"
+  bio: "CS PhD @ucdavis,\r\nRustacean and Pythonista.\r\nPreviously: @dib-lab"
+  organization:
   github_username: luizirber
   github_image_id: 6642
   contributor_type:
     - editor
-  packages-submitted: [""]
-  packages-reviewed: [""]
-  packages-editor: ["earthpy"]
+  packages-submitted:
+    -
+  packages-reviewed:
+    -
+  packages-editor:
+    - earthpy
+  twitter:
+  website: https://luizirber.org
+  location: Davis, CA
+  email:
 - name: Paige Bailey
-  bio: ''
-  organization: "Google"
-  github_username:
+  bio: ✨ Keep it simple, and make it scale. AI should be about empowering users
+    and building understanding. @anyscale @ray-project 👩🏼‍💻 Lead | ex-@DeepMind
+    @Google
+  organization: "@GitHub"
+  github_username: dynamicwebpaige
   github_image_id: 3712347
   contributor_type:
     - contributor
-  packages-submitted: [""]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter: dynamicwebpaige
+  website: http://paigevie.ws
+  location: Seattle, WA
+  email: paige.bailey@alumni.rice.edu
 - name: Carson Farmer
-  bio: ''
-  organization: "Textileio"
-  github_username:
+  bio: Research & Development @textileio and @tablelandnetwork
+  organization: "@textileio @tablelandnetwork"
+  github_username: carsonfarmer
   github_image_id: 1220613
   contributor_type:
     - contributor
-  packages-submitted: [""]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter: carsonfarmer
+  website: http://carsonfarmer.com
+  location: Victoria, B.C., Canada
+  email: carson.farmer@gmail.com
 - name: Joe Hamman
-  bio: ''
-  organization: "NCAR, Pangeo"
-  github_username:
+  bio: "Scientist and Engineer and Human.\r\n"
+  organization:
+  github_username: jhamman
   github_image_id: 2443309
   contributor_type:
     - contributor
-  packages-submitted: [""]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter: _jhamman
+  website: http://joehamman.com
+  location: Seattle, WA
+  email: jhamman1@gmail.com
 - name: Kylen Solvik
-  bio: ''
-  organization: "CU Boulder"
-  github_username:
+  bio:
+  organization:
+  github_username: kysolvik
   github_image_id: 24379590
   contributor_type:
     - contributor
-  packages-submitted: [""]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter:
+  website:
+  location:
+  email: kysolvik@gmail.com
 - name: Martin Skarzynski
-  bio: ''
-  organization: "NCI Biostatistics Branch"
-  github_username:
+  bio: "\U0001F9EEBiostatistics Branch\U0001F3DBNCI Division of\U0001F980Cancer\
+    \ Epidemiology and\U0001F9ECGenetics (DCEG)\r\n\U0001F4BBBioinformatics\U0001F4CA\
+    DataScience\U0001F4BACo-chair\U0001F393FAES\r\n\U0001F40DPython®Rstats⚕Health\U0001F916\
+    ML\U0001F9E0AI"
+  organization:
+  github_username: marskar
   github_image_id: 12806339
   contributor_type:
     - contributor
-  packages-submitted: [""]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter:
+  website: https://marskar.github.io/
+  location: Rockville/Bethesda, Maryland
+  email:
 - name: Mike Trizna
-  bio: ''
-  organization: ""
-  github_username:
+  bio:
+  organization: Smithsonian Institution
+  github_username: miketrizna
   github_image_id: 472677
   contributor_type:
     - contributor
-  packages-submitted: [""]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter:
+  website:
+  location: Washington, DC
+  email: triznam@si.edu
 - name: Neil Chue Hong
-  bio: ''
-  organization: "Software Sustainability Institute"
-  github_username:
+  bio:
+    Director of the Software Sustainability Institute (@softwaresaved). Editor-in-Chief
+    of the Journal of Open Research Software. Interested in software metrics.
+  organization: "@softwaresaved "
+  github_username: npch
   github_image_id: 1507151
   contributor_type:
     - contributor
-  packages-submitted: [""]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter:
+  website: http://www.software.ac.uk
+  location: Edinburgh, United Kingdom
+  email:
 - name: Niels Bantilan
-  bio: ''
-  organization: ""
+  bio: Data Scientist, Machine Learning Engineer
+  organization: "@unionai"
   github_username: cosmicBboy
   github_image_id: 2816689
   contributor_type:
     - contributor
     - package-maintainer
-  packages-submitted: ["pandera"]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    - pandera
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter: cosmicbboy
+  website: http://cosmicbboy.github.io/
+  location: Atlanta, GA, US
+  email: niels.bantilan@gmail.com
 - name: Sean Gillies
-  bio: ''
-  organization: "Mapbox"
+  bio: b. 1969, he/him
+  organization: "@planetlabs"
   github_username: sgillies
   github_image_id: 33697
   contributor_type:
     - reviewer
-  packages-submitted: [""]
-  packages-reviewed: ["earthpy"]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    - earthpy
+  packages-editor:
+    -
+  twitter: sgillies
+  website: https://sgillies.net
+  location: Fort Collins, Colorado
+  email: sean.gillies@gmail.com
 - name: Rohit Goswami
-  bio: ''
-  organization: "University of Iceland"
+  bio:
+  organization: "@Quansight-Labs, @TheochemUI"
   github_username: HaoZeke
   github_image_id: 4336207
   contributor_type:
     - reviewer
-  packages-submitted: [""]
-  packages-reviewed: ["earthpy"]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    - earthpy
+  packages-editor:
+    -
+  twitter: rg0swami
+  website: https://rgoswami.me
+  location: University of Iceland
+  email: rog32@hi.is
 - name: Morgan Williams
-  bio: 'Postdoctoral Fellow, Geoscience Analytics'
-  organization: "CSIRO"
+  bio:
+  organization: CSIRO
   github_username: morganjwilliams
   github_image_id: 11415019
   contributor_type:
     - package-maintainer
-  packages-submitted: ["pyrolite"]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    - pyrolite
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter: metasomite
+  website:
+  location: Perth, WA, Australia
+  email:
 - name: Philip Meier
-  bio: 'PhD student working on Neural Style Transfer'
-  organization: "Quansight"
+  bio: Software Engineer [he/him/his] working on PyTorch / torchvision
+  organization: "@Quansight "
   github_username: pmeier
   github_image_id: 6849766
   contributor_type:
     - package-maintainer
     - reviewer
-  packages-submitted: ["pystiche"]
-  packages-reviewed: ["sevivi"]
-  packages-editor: [""]
+  packages-submitted:
+    - pystiche
+  packages-reviewed:
+    - sevivi
+  packages-editor:
+    -
+  twitter:
+  website:
+  location: Germany
+  email:
 - name: Edgar Riba
-  bio: "Computer Vision Research Engineer"
-  organization: "Farm-ng, Kornia/OpenCV.org"
+  bio: "@kornia Creator | PhD, Computer Vision Research Engineer"
+  organization: Kornia.org
   github_username: edgarriba
   github_image_id: 5157099
   contributor_type:
     - reviewer
-  packages-submitted: [""]
-  packages-reviewed: ["pystiche", "sevivi"]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    - pystiche
+    - sevivi
+  packages-editor:
+    -
+  twitter: edgarriba
+  website: www.kornia.org
+  location: Barcelona, Spain
+  email: edgar.riba@gmail.com
 - name: DOV-Vlaanderen
-  bio: ''
-  organization: "DOV-Vlaanderen"
+  bio:
+  organization:
   github_username: DOV-Vlaanderen
   github_image_id: 24718915
   contributor_type:
     - package-maintainer
-  packages-submitted: ["pydov"]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    - pydov
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter:
+  website: https://www.dov.vlaanderen.be
+  location:
+  email:
 - name: Roel Huybrechts
-  bio: ''
-  organization: ""
+  bio:
+  organization:
   github_username: Roel
   github_image_id: 140299
   contributor_type:
     - package-maintainer
-  packages-submitted: ["pydov"]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    - pydov
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter:
+  website: https://mastodon.social/@rhuybrec
+  location:
+  email: roel@huybrechts.re
 - name: Stijn Van Hoey
-  bio: ''
-  organization: "Fluves"
+  bio:
+  organization: "@fluves "
   github_username: stijnvanhoey
   github_image_id: 754862
   contributor_type:
     - package-maintainer
-  packages-submitted: ["pydov"]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    - pydov
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter:
+  website:
+  location:
+  email:
 - name: Pieter Jan Haest
-  bio: ''
-  organization: "De Watergroep"
+  bio: Project manager industry 4.0
+  organization: De Watergroep
   github_username: pjhaest
   github_image_id: 22764347
   contributor_type:
     - package-maintainer
-  packages-submitted: ["pydov"]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    - pydov
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter:
+  website: https://corporate.dewatergroep.be/en
+  location: Belgium
+  email:
 - name: Nhat (Jonny) Tran
-  bio: ''
-  organization: "University of Texas at Arlington"
+  bio: Graph neural networks, bioinformatics, non-coding RNA, NLP, and ML engineering.
+  organization: Actively looking
   github_username: JonnyTran
   github_image_id: 4750391
   contributor_type:
     - package-maintainer
-  packages-submitted: ["openomics"]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    - openomics
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter: Jonny_Wireless
+  website: jonny.bio
+  location:
+  email:
 - name: Katharina Sielemann
-  bio: ''
-  organization: "Bielefeld University"
+  bio:
+  organization:
   github_username: ksielemann
   github_image_id: 62541949
   contributor_type:
     - reviewer
-  packages-submitted: [""]
-  packages-reviewed: ["openomics"]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    - openomics
+  packages-editor:
+    -
+  twitter: ksielemann
+  website:
+  location:
+  email:
 - name: Moritz Lürig
-  bio: 'postdoc in ecology and evolution'
-  organization: "Lund University"
+  bio:
+    Postdoc in ecology and evolution; interested in computer vision and ecological
+    informatics
+  organization: Lund University
   github_username: mluerig
   github_image_id: 15648068
   contributor_type:
     - contributor
     - package-maintainer
-  packages-submitted: ["phenopype"]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    - phenopype
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter: mluerig
+  website: www.luerig.net
+  location: Sweden
+  email: moritz.luerig@gmail.com
 - name: Emily Jane McTavish
-  bio: 'Assistant Professor, Life and Environmental Sciences'
-  organization: "University of California, Merced"
+  bio:
+  organization:
   github_username: snacktavish
   github_image_id: 1652782
   contributor_type:
     - contributor
     - package-maintainer
-  packages-submitted: ["physcraper"]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    - physcraper
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter:
+  website: McTavishLab.github.io
+  location:
+  email: ejmctavish@ucmerced.edu
 - name: Luna L. Sanchez Reyes
-  bio: 'Postdoctoral Researcher: Evolutionary biology and Open Science for phylogenetics research and education.'
-  organization: "University of California, Merced"
+  bio: "Nature. Computers. Life. \r\nDoing open science with @phylotastic and @OpenTreeOfLife"
+  organization: University of California, Merced
   github_username: LunaSare
   github_image_id: 26721915
   contributor_type:
     - contributor
     - package-maintainer
-  packages-submitted: ["physcraper"]
-  packages-reviewed: [""]
-  packages-editor: [""]
+  packages-submitted:
+    - physcraper
+  packages-reviewed:
+    -
+  packages-editor:
+    -
+  twitter: LunaSare
+  website: www.lunasare.com
+  location: Merced, CA, USA
+  email: sanchez.reyes.luna@gmail.com
 - name: K. Arthur Endsley
-  bio: 'Computational Geoscientist'
-  organization: "W.A. Franke College of Forestry and Conservation, University of Montana"
+  bio: Computational Geoscientist
+  organization: University of Montana NTSG
   github_username: arthur-e
   github_image_id: 1211103
   contributor_type:
     - reviewer
-  packages-submitted: [""]
-  packages-reviewed: ["Jointly"]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    - Jointly
+  packages-editor:
+    -
+  twitter:
+  website: http://karthur.org/
+  location: Missoula, MT
+  email: endsley@umich.edu
 - name: Alejandro Sáez Mollejo
-  bio: 'Aerospace engineer'
-  organization: ""
+  bio:
+    "Aerospace engineer passionate about Flight Mechanics.\r\nPython, Fortran,\
+    \ Matlab and lately Julia. (These are my personal projects)"
+  organization: AIRBUS D&S
   github_username: alexs12
   github_image_id: 6061587
   contributor_type:
     - reviewer
-  packages-submitted: [""]
-  packages-reviewed: ["jointly"]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    - jointly
+  packages-editor:
+    -
+  twitter:
+  website: https://www.linkedin.com/in/alejandrosaezm
+  location: Madrid (Spain)
+  email: alex.saez.12@gmail.com
 - name: Julius Busecke
-  bio: ''
-  organization: "Columbia University"
+  bio: "Climate Scientist | \r\nOceanographer |\r\nOpen Source Enthusiast"
+  organization: "Columbia/LDEO -- @ocean-transport "
   github_username: jbusecke
   github_image_id: 14314623
   contributor_type:
     - reviewer
-  packages-submitted: [""]
-  packages-reviewed: ["PyGMT"]
-  packages-editor: [""]
+  packages-submitted:
+    -
+  packages-reviewed:
+    - PyGMT
+  packages-editor:
+    -
+  twitter: JuliusBusecke
+  website: http://www.juliusbusecke.com
+  location: Brooklyn, New York
+  email:
 - name: Szymon Moliński
-  bio: 'Head of Data Science | Spatial | Time Series'
-  organization: "Digitree S.A. | HackerSpace"
+  bio: GIS, remote sensing, machine learning, time-series and spatial
+  organization: Sare
   github_username: SimonMolinsky
   github_image_id: 31246246
   contributor_type:
     - reviewer
-  packages-submitted: [""]
-  packages-reviewed: ["PyGMT"]
-  packages-editor: [""]
-- name: "Nicolas Palopoli"
-  bio: "Co-Executive Director, MetaDocencia. Adjunct Researcher, Universidad Nacional de Quilmes & CONICET"
-  organization: "MetaDocencia"
-  github_username: "npalopoli"
-  github_image_id: 1713937 # You can find this by right clicking on the image in your bio, and copying the link. the last part contains a 7 digit number that is your avatar image!
-  title: "Co-Executive Director"
-  twitter: "NPalopoli" 
-  mastodon: "https://fediscience.org/@npalopoli"
+  packages-submitted:
+    -
+  packages-reviewed:
+    - PyGMT
+  packages-editor:
+    -
+  twitter:
+  website: ml-gis-service.com
+  location:
+  email: simon@ml-gis-service.com
+- name: Nicolas Palopoli
+  bio: Computational Biologist
+  organization: Universidad Nacional de Quilmes & Fundación Instituto Leloir
+  github_username: npalopoli
+  github_image_id: 1713937
+  title: Co-Executive Director
+  twitter:
+  mastodon: https://fediscience.org/@npalopoli
   orcidid: ​0000-0001-7925-6436
-  website: https://about.me/npalopoli
+  website: http://about.me/npalopoli
+  location: Buenos Aires, Argentina
+  email: nicopalo@gmail.com
+- name: Erik Welch
+  contributions:
+    - code
+    - review
+    - design
+  github_username: eriknw
+  website: https://fosstodon.org/@eriknw
+  github_image_id: 2058401
+  mastodon:
+  twitter: eriknwelch
+  bio:
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: Austin, TX
+  organization:
+  email:
+- name: Pamphile Roy
+  contributions:
+    - doc
+    - design
+  github_username: tupui
+  website:
+  github_image_id: 23188539
+  mastodon:
+  twitter: PamphileRoy
+  bio: Artificial Intelligence & Backend Engineer probably doing some Python 🐍 ❤️
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: Graz, Austria
+  organization: "@Quansight"
+  email: roy.pamphile@gmail.com
+- name: Jonny Saunders
+  contributions:
+    - code
+    - design
+  github_username: sneakers-the-rat
+  website: https://jon-e.net
+  github_image_id: 12961499
+  mastodon:
+  twitter: json_dirs
+  bio: Bad at programming in beautiful Oregon
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location:
+  organization:
+  email:
+- name: Randy Döring
+  contributions:
+    - code
+    - review
+  github_username: radoering
+  website:
+  github_image_id: 30527984
+  mastodon:
+  twitter:
+  bio:
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location:
+  organization:
+  email:
+- name: Juan Luis Cano Rodríguez
+  contributions:
+    - code
+    - design
+    - review
+  github_username: astrojuanlu
+  website:
+  github_image_id: 316517
+  mastodon:
+  twitter:
+  bio: Open Knowledge + Radical Transparency
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: Spain
+  organization: "@kedro-org"
+  email: hello@juanlu.space
+- name: Henry Schreiner
+  contributions:
+    - code
+    - design
+    - review
+  github_username: henryiii
+  website: iscinumpy.dev
+  github_image_id: 4616906
+  mastodon:
+  twitter: henryschreiner3
+  bio:
+    Particle physicist and software architect working with @iris-hep. @scikit-hep,
+    @pybind, and @scikit-build admin. @pypa member.
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: Princeton, NJ
+  organization: Princeton University
+  email: HenrySchreinerIII@gmail.com
+- name: Stefan van der Walt
+  contributions:
+    - code
+    - review
+    - design
+  github_username: stefanv
+  website: https://mentat.za.net
+  github_image_id: 45071
+  mastodon:
+  twitter: stefanvdwalt
+  bio: Researcher at Berkeley Institute for Data Science, open source scientific
+    Python developer (NumPy, scikit-image, etc.), author of Elegant SciPy.
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: Berkeley, CA
+  organization: University of California, Berkeley
+  email:
+- name: Eli Schwartz
+  contributions:
+    - code
+    - design
+    - review
+  github_username: eli-schwartz
+  website:
+  github_image_id: 6551424
+  mastodon:
+  twitter:
+  bio: "@archlinux bugwrangler and Trusted User"
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location:
+  organization:
+  email: eschwartz93@gmail.com
+- name: Ralf Gommers
+  contributions:
+    - code
+    - design
+    - review
+  github_username: rgommers
+  website: https://github.com/rgommers/
+  github_image_id: 98330
+  mastodon:
+  twitter: ralfgommers
+  bio: NumPy, SciPy, data-apis.org, PyWavelets maintainer. Building open source
+    communities at Quansight Labs. He/him.
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: Netherlands
+  organization: Quansight
+  email: ralf.gommers@gmail.com
+- name: Pradyun Gedam
+  contributions:
+    - code
+    - design
+    - review
+  github_username: pradyunsg
+  website: https://pradyunsg.me
+  github_image_id: 3275593
+  mastodon:
+  twitter: pradyunsg
+  bio:
+    "@pypa member, @psf fellow, @toml-lang core, @sphinx-doc contributor. Past\
+    \ intern at @enthought and IITB.\r\n\r\nDon't email or tweet me for tech support."
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: London, UK
+  organization: "@bloomberg Python Infrastructure"
+  email:
+- name: Ofek Lev
+  contributions:
+    - code
+    - design
+    - review
+  github_username: ofek
+  website: https://ofek.dev
+  github_image_id: 9677399
+  mastodon:
+  twitter:
+  bio: I like developing beautiful APIs.
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: Knowhere
+  organization: "@datadog"
+  email: oss@ofek.dev
+- name: Tom Augspurger
+  contributions:
+    - code
+    - review
+    - design
+  github_username: TomAugspurger
+  website: https://tomaugspurger.github.io
+  github_image_id: 1312546
+  mastodon:
+  twitter:
+  bio:
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location:
+  organization: "@microsoft"
+  email: tom.w.augspurger@gmail.com
+- name: Ryan Abernathey
+  contributions:
+    - code
+    - design
+    - review
+  github_username: rabernat
+  website: https://github.com/rabernat
+  github_image_id: 1197350
+  mastodon:
+  twitter: rabernat
+  bio: Open source maintainer. CEO and co-founder of @earth-mover. @pangeo-data
+    creator. Professor of Earth and Environmental Sciences at Columbia University.
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: New York City
+  organization: Earthmover PBC
+  email:
+- name: Carol Willing
+  contributions:
+    - review
+    - code
+  github_username: willingc
+  website: https://hachyderm.io/web/@willingc
+  github_image_id: 2680980
+  mastodon:
+  twitter: WillingCarol
+  bio:
+    "Project Jupyter, nteract, and CPython core developer\r\n\r\n@python | @jupyter\
+    \ | @jupyterhub | @ipython | @nteract | @pysplash"
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: San Diego
+  organization: Willing Consulting
+  email: carolcode@willingconsulting.com
+- name: Steve Moss
+  contributions:
+    - review
+    - code
+  github_username: gawbul
+  website: https://www.gawbul.io
+  github_image_id: 321291
+  mastodon:
+  twitter: gawbul
+  bio:
+    Dad, husband, and PhD 👨‍🎓 Scientist 👨‍🔬 Technologist 📱 Engineer 👨‍💻 Bibliophile
+    📚 Philomath 🧐
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: Earth
+  organization: Dr Stephen P. Moss
+  email:
+- name: Matthew Brett
+  contributions:
+    - review
+    - code
+  github_username: matthew-brett
+  website: https://matthew.dynevor.org
+  github_image_id: 67612
+  mastodon:
+  twitter:
+  bio:
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: London, UK
+  organization: London Interdisciplinary School
+  email:
+- name: Zehua Chen
+  contributions:
+    - review
+    - code
+  github_username: ReventonC
+  website: zehuachen.com
+  github_image_id: 6276623
+  mastodon:
+  twitter:
+  bio: "Cat-centered Design.\r\n"
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: Atlanta, GA
+  organization:
+  email:
+- name: Sumit Kashyap
+  contributions:
+    - code
+    - review
+  github_username: sumit-158
+  website:
+  github_image_id: 96618001
+  mastodon:
+  twitter: itss_sumit
+  bio: Open source and community | GSoC' 22 @openfoodfacts |
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: India
+  organization:
+  email: mr.sumitkrr@gmail.com
+- name: Erik Sundell
+  contributions:
+    - review
+    - code
+  github_username: consideRatio
+  website:
+  github_image_id: 3837114
+  mastodon:
+  twitter: e_Sundell
+  bio:
+    "Climate change mitigation efforts need nuclear alongside other low carbon\
+    \ sources.\r\n\r\nhttps://twitter.com/e_Sundell/status/1258480862359937024"
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: Sweden
+  organization: Sundell Open Source Consulting AB
+  email: erik.i.sundell@gmail.com
+- name: Ariel Rokem
+  contributions:
+    - review
+    - code
+  github_username: arokem
+  website: http://arokem.org
+  github_image_id: 118582
+  mastodon:
+  twitter:
+  bio:
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: Seattle, WA
+  organization: The University of Washington eScience Institute
+  email: arokem@gmail.com
+- name: James Mason
+  contributions:
+    - review
+    - code
+  github_username: jmason86
+  website: jamespaulmason.com
+  github_image_id: 947614
+  mastodon:
+  twitter: starfleetjames
+  bio:
+    solar physics, space weather, and aerospace engineering. principal investigator
+    of nasa's suncet mission.
+  orcidid:
+  contributor_type:
+  packages-submitted:
+  packages-reviewed:
+  location: Washington DC
+  organization: Johns Hopkins Applied Physics Lab
+  email:

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -33,7 +33,6 @@
   github_image_id: 889238
   title: Board chair
   board: true
-  website:
   location:
   email: tkteal@gmail.com
 - name: Karen Cranston
@@ -102,7 +101,7 @@
   twitter: xmnlab
   mastodon:
   orcidid: 0000-0001-5049-4289
-  website:
+  website: https://xmnlab.github.io
   editor:
   contributor_type:
     - reviewer
@@ -184,7 +183,7 @@
   twitter:
   mastodon: https://hachyderm.io/@yuvipanda
   orcidid:
-  website:
+  website: https://words.yuvi.in
   contributor_type: []
   packages-submitted:
     -
@@ -272,7 +271,7 @@
   twitter:
   mastodon:
   orcidid:
-  website: https://linkedin.com/in/jennypalomino
+  website:
   contributor_type:
     - reviewer
     - contributor
@@ -407,7 +406,6 @@
   packages-editor:
     -
   twitter: dynamicwebpaige
-  website: https://paigevie.ws
   location: Seattle, WA
   email: paige.bailey@alumni.rice.edu
 - name: Carson Farmer
@@ -458,7 +456,6 @@
   packages-editor:
     -
   twitter:
-  website:
   location:
   email: kysolvik@gmail.com
 - name: Martin Skarzynski
@@ -495,7 +492,6 @@
   packages-editor:
     -
   twitter:
-  website:
   location: Washington, DC
   email: triznam@si.edu
 - name: Neil Chue Hong
@@ -583,7 +579,6 @@
   packages-editor:
     -
   twitter: metasomite
-  website:
   location: Perth, WA, Australia
   email:
 - name: Philip Meier
@@ -601,7 +596,6 @@
   packages-editor:
     -
   twitter:
-  website:
   location: Germany
   email:
 - name: Edgar Riba
@@ -619,7 +613,6 @@
   packages-editor:
     -
   twitter: edgarriba
-  website: https://www.kornia.org
   location: Barcelona, Spain
   email: edgar.riba@gmail.com
 - name: DOV-Vlaanderen
@@ -670,7 +663,6 @@
   packages-editor:
     -
   twitter:
-  website:
   location:
   email:
 - name: Pieter Jan Haest
@@ -721,7 +713,6 @@
   packages-editor:
     -
   twitter: ksielemann
-  website:
   location:
   email:
 - name: Moritz Lürig
@@ -794,7 +785,6 @@
   packages-editor:
     -
   twitter:
-  website: https://karthur.org/
   location: Missoula, MT
   email: endsley@umich.edu
 - name: Alejandro Sáez Mollejo
@@ -813,7 +803,6 @@
   packages-editor:
     -
   twitter:
-  website: https://www.linkedin.com/in/alejandrosaezm
   location: Madrid (Spain)
   email: alex.saez.12@gmail.com
 - name: Julius Busecke
@@ -830,7 +819,6 @@
   packages-editor:
     -
   twitter: JuliusBusecke
-  website: https://www.juliusbusecke.com
   location: Brooklyn, New York
   email:
 - name: Szymon Moliński
@@ -885,7 +873,7 @@
     - doc
     - design
   github_username: tupui
-  website:
+  website: https://github.com/tupui
   github_image_id: 23188539
   mastodon:
   twitter: PamphileRoy
@@ -919,7 +907,7 @@
     - code
     - review
   github_username: radoering
-  website:
+  website: https://github.com/radoering
   github_image_id: 30527984
   mastodon:
   twitter:
@@ -937,7 +925,7 @@
     - design
     - review
   github_username: astrojuanlu
-  website:
+  website: https://social.juanlu.space/@astrojuanlu
   github_image_id: 316517
   mastodon:
   twitter:
@@ -994,7 +982,7 @@
     - design
     - review
   github_username: eli-schwartz
-  website:
+  website: https://github.com/eli-schwartz
   github_image_id: 6551424
   mastodon:
   twitter:
@@ -1160,7 +1148,7 @@
     - review
     - code
   github_username: ReventonC
-  website: https://zehuachen.com
+  website: http://zehuachen.com
   github_image_id: 6276623
   mastodon:
   twitter:
@@ -1177,7 +1165,7 @@
     - code
     - review
   github_username: sumit-158
-  website:
+  website: https://github.com/sumit-158
   github_image_id: 96618001
   mastodon:
   twitter: itss_sumit
@@ -1194,7 +1182,7 @@
     - review
     - code
   github_username: consideRatio
-  website:
+  website: https://github.com/consideRatio
   github_image_id: 3837114
   mastodon:
   twitter: e_Sundell

--- a/_pages/contributors.md
+++ b/_pages/contributors.md
@@ -5,24 +5,25 @@ title: "The pyOpenSci Team & Contributors"
 excerpt: "pyOpenSci is a diverse community of people interested in building a community of practice around scientific software written in Python."
 classes:
 header:
-    overlay_image: images/header.jpg
-    overlay_filter: 0.6
+  overlay_image: images/header.jpg
+  overlay_filter: 0.6
 redirect_from:
   - /contributors.html
 ---
 
-## Our pyOpenSci Community 
+## Our pyOpenSci Community
 
-<!-- 
+<!--
 {{ site.data.contributors | size }} people have contributed to pyOpenSci as
-of today! 
-TODO add this advisory committee role to the governance 
+of today!
+TODO add this advisory committee role to the governance
 -->
 
-pyOpenSci has one core paid staff member who leads the organization. We are supported 
+pyOpenSci has one core paid staff member who leads the organization. We are supported
 by an expert team of volunteer advisory members who help steer the direction of the organization.
 
 ## Executive council & leadership
+
 {: .clearall }
 
 {% assign advisory_sorted = site.data.contributors | where:"board",true | sort: 'sort' %}
@@ -33,12 +34,15 @@ by an expert team of volunteer advisory members who help steer the direction of 
 {% endfor %}
 </div>
 
-## PyOpenSci advisory council 
 {: .clearall }
 
-pyOpenSci advisory council members are volunteer experts in the scientific 
-Python open source space who provide high-level guidance on the development of 
-the organization. 
+## PyOpenSci advisory council
+
+{: .clearall }
+
+pyOpenSci advisory council members are volunteer experts in the scientific
+Python open source space who provide high-level guidance on the development of
+the organization.
 
 {% assign advisory_working = site.data.contributors | where:"advisory",true | sort: 'sort' %}
 
@@ -50,8 +54,10 @@ the organization.
 {% endfor %}
 </div>
 
+{: .clearall }
 
 ## PyOpenSci community contributors
+
 {: .clearall }
 
 {% assign ppl_sorted = site.data.contributors | reverse %}
@@ -60,14 +66,8 @@ the organization.
 {% for aperson in ppl_sorted %}
   {% unless aperson.board %}
   {% unless aperson.advisory %}
-  {% unless aperson.editorial-board %}
     {% include people-grid.html  %}
-  {% endunless %}
   {% endunless %}
   {% endunless %}
 {% endfor %}
 </div>
-
-
-
-

--- a/_posts/2023-01-26-community-manager-job-available.md
+++ b/_posts/2023-01-26-community-manager-job-available.md
@@ -79,7 +79,7 @@ global, we prefer that you live in the United States.
 * Identify and fill gaps in pyOpenSci’s web resources, including our peer review  and Python packaging guide
 
 ## About You - What experience you need for this position
-* Bachelor’s degree (or equivalent experience) in a relevant discipline such as science, math, engineering, or computer science
+* Experience working in a relevant discipline such as science communication, science, math, engineering, or computer science (or a bachelors degree in this space)
 * Fluency speaking english
 * 2+ years of experience working with and managing communities that support open source projects or the data science space as an evangelist, advocate, or organizer
 * Experience creating strategic content for social media platforms and tools (specifically Twitter and Mastodon) and fostering online engagement
@@ -95,6 +95,7 @@ global, we prefer that you live in the United States.
 * Fluency speaking Spanish
 * Experience developing or contributing to open source software 
 * Experience or familiarity with Python programming 
+* Bachelors degree in STEM or communications.
 
 ## What to expect
 


### PR DESCRIPTION
Yay! this updates our contributors on the website from all of the all-contributors json files across our organization. It also updates user metadata from their GH repo so we don't have to worry about curating that over time!

Eventually we can automate this workflow (below) via ci which should be straight forward!

https://github.com/pyOpenSci/update-web-metadata