### PR TITLE
Fix: highlighted packages, editor grid css

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -360,6 +360,27 @@
     - erddapy
   location:
   email:
+- name: Szymon Moliński
+  title: Editor
+  editorial-board: true
+  bio: GIS, remote sensing, machine learning, time-series and spatial
+  organization: Sare
+  github_username: SimonMolinsky
+  github_image_id: 31246246
+  contributor_type:
+    - editor
+    - reviewer
+    - guidebook-contrib
+  packages-submitted:
+    -
+  packages-reviewed:
+    - PyGMT
+  packages-editor:
+    -
+  twitter:
+  website: https://ml-gis-service.com
+  location:
+  email: simon@ml-gis-service.com
 - name: Anita Graser
   bio: 'Spatial data science with a focus on mobility & data quality '
   organization:
@@ -892,24 +913,6 @@
   website:
   location: Brooklyn, New York
   email:
-- name: Szymon Moliński
-  bio: GIS, remote sensing, machine learning, time-series and spatial
-  organization: Sare
-  github_username: SimonMolinsky
-  github_image_id: 31246246
-  contributor_type:
-    - reviewer
-    - guidebook-contrib
-  packages-submitted:
-    -
-  packages-reviewed:
-    - PyGMT
-  packages-editor:
-    -
-  twitter:
-  website: https://ml-gis-service.com
-  location:
-  email: simon@ml-gis-service.com
 - name: Nicolas Palopoli
   bio: Computational Biologist
   organization: Universidad Nacional de Quilmes & Fundación Instituto Leloir

--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -1,4 +1,5 @@
 - package_name: afscgap
+  highlight: true
   package_description: Tools for analysis and inference in NOAA AFSC GAP marine
           species presence data.
   submitting_author:
@@ -38,6 +39,7 @@
       contrib_count: 2
       last_commit: 05/31/2023
 - package_name: xclim
+  highlight: true
   package_description: Climate indices computation package based on Xarray
   submitting_author:
       github_username: Zeitsperre
@@ -82,6 +84,7 @@
       contrib_count: 26
       last_commit: 04/21/2023
 - package_name: crowsetta
+  highlight: true
   package_description: A Python tool to work with any format for annotating animal
       vocalizations and bioacoustics data.
   submitting_author:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,4 +26,5 @@
   <div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}</div>
   <script src="https://code.jquery.com/jquery-3.6.1.min.js" integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ=" crossorigin="anonymous"></script>
   <script src="https://npmcdn.com/isotope-layout@3/dist/isotope.pkgd.js"></script>
+  <script src="https://npmcdn.com/imagesloaded@4/imagesloaded.pkgd.js"></script>
   <script src="/assets/js/dropdown.js"></script>

--- a/_pages/about-peer-review.md
+++ b/_pages/about-peer-review.md
@@ -8,7 +8,7 @@ header:
 intro:
   - excerpt: "Our open peer review process supports scientists getting credit for the work invested in open Python tools. It also supports standardization of packaging and improved package visibility."
 toc: false
-classes: wide
+classes:
 ---
 
 {% include feature_row id="intro" type="center" %}
@@ -62,12 +62,14 @@ classes: wide
 
 ## Our editorial board
 
-We value our volunteer editors. Learn more about what editors do and how we select
-them here.
+{: .clearall }
+
+We value our volunteer editors. Learn more about what editors do and how we
+select them here.
 
 {% assign editors = site.data.contributors | where: 'editorial-board', true  %}
 
-<div class="entries-grid">
+<div class="grid">
 {% for aperson in editors %}
 {% unless aperson.board %}
     {% include people-grid.html  %}
@@ -75,10 +77,12 @@ them here.
 {% endfor %}
 </div>
 
-<br style="clear:both">
+<br clear="both">
 
 <div class="wide__p_text" markdown="1">
+
 ## Why Peer Review for Python Scientific Software?
+
 Peer review of Python scientific software addresses several challenges in the
 open source community:
 
@@ -143,11 +147,11 @@ are, in places, less stringent than those of pyOpenSci.
 ## Recently Accepted Python Packages
 
 <div class="grid">
-    {% for apackage in site.data.packages %}
+  {% for apackage in site.data.packages %}
     {% if apackage.highlight %}
-{% include package-grid.html  %}
+      {% include package-grid.html  %}
     {% endif %}
-    {% endfor %}
+  {% endfor %}
 </div>
 
 <br clear="both">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -929,7 +929,9 @@ input[type="text"] {
 
 /* ---- .element-item ---- */
 
-
+.grid .element-item {
+  width: auto;
+}
 
 .element-item {
   position: relative;

--- a/assets/js/dropdown.js
+++ b/assets/js/dropdown.js
@@ -42,8 +42,8 @@ var qsRegex;
 var buttonFilter;
 
 // init Isotope
-var $grid = $(window).on('load', function() {
-  $('.grid-isotope').isotope({
+var $grid = $('.grid-isotope').imagesLoaded( function() {
+  $grid.isotope({
     itemSelector: '.element-item',
     layoutMode: 'masonry',
     masonry: {
@@ -56,7 +56,7 @@ var $grid = $(window).on('load', function() {
       var buttonResult = buttonFilter ? $this.is( buttonFilter ) : true;
       return searchResult && buttonResult;
     }
-  })
+  });
 });
 
 $('#filters').on( 'click', 'button', function() {

--- a/assets/js/dropdown.js
+++ b/assets/js/dropdown.js
@@ -42,19 +42,21 @@ var qsRegex;
 var buttonFilter;
 
 // init Isotope
-var $grid = $('.grid-isotope').isotope({
-  itemSelector: '.element-item',
-  layoutMode: 'masonry',
-  masonry: {
-    columnWidth: 80,
-    horizontalOrder: false,
-  },
-  filter: function() {
-    var $this = $(this);
-    var searchResult = qsRegex ? $this.text().match( qsRegex ) : true;
-    var buttonResult = buttonFilter ? $this.is( buttonFilter ) : true;
-    return searchResult && buttonResult;
-  }
+var $grid = $(window).on('load', function() {
+  $('.grid-isotope').isotope({
+    itemSelector: '.element-item',
+    layoutMode: 'masonry',
+    masonry: {
+      columnWidth: 80,
+      horizontalOrder: false,
+    },
+    filter: function() {
+      var $this = $(this);
+      var searchResult = qsRegex ? $this.text().match( qsRegex ) : true;
+      var buttonResult = buttonFilter ? $this.is( buttonFilter ) : true;
+      return searchResult && buttonResult;
+    }
+  })
 });
 
 $('#filters').on( 'click', 'button', function() {


### PR DESCRIPTION
FIxes here:

1. load images prior to isotope grid initializing to avoid flattened images on load
2. Fix package grid by making sure highlighted packages as in the packages.yml file 
3. Fix funny spacing of isotope grid on packages page and community page


This is a start at fixing the grid items on the website. 

The packages highlight was broken because when i auto updated the packages page it removes the highlight field. This is a bug in my update web metadata workflow that i need to fix. 

<img width="877" alt="Screen Shot 2023-06-08 at 2 18 13 PM" src="https://github.com/pyOpenSci/pyopensci.github.io/assets/7649194/d00428e3-8a19-4950-963a-9144689a7d30">

the editorial team listing has a gap - this is an isotope issue. the fix for this is just to use the regular `grid` style vs isotope and it should look better. 
<img width="1052" alt="Screen Shot 2023-06-08 at 2 19 09 PM" src="https://github.com/pyOpenSci/pyopensci.github.io/assets/7649194/5d3a24b4-f0a6-46a4-a5ad-58c07cc6fb29">

## Squashed images

the next issue is that the grid sometimes loads squished - like this:

<img width="1193" alt="Screen Shot 2023-06-08 at 2 20 06 PM" src="https://github.com/pyOpenSci/pyopensci.github.io/assets/7649194/71102f16-8839-4a51-9ba4-c35ca0f54452">

 i added an onload `$(window).on('load', function() {` element to the js to try to give it time to load properly.  it might be working better now as far as i can tell locally. BUT that onload seems to be causing a gap in the listing of cards which is confusing??? 
