### PR TITLE
Adjusts CSS to not hide the logo when the dropdox is visible

### DIFF
--- a/_sass/minimal-mistakes/_pyos-dropdown.scss
+++ b/_sass/minimal-mistakes/_pyos-dropdown.scss
@@ -81,7 +81,7 @@ drop shadow
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  padding-top: 2em;
+  margin-top: 2em;
   top: 90%;
   left: 0%;
   width: 100%;


### PR DESCRIPTION
Related to https://github.com/pyOpenSci/pyopensci.github.io/issues/208 (If this was intended, you are welcome to close this PR.)

### On Main

![Screenshot 2023-07-15 at 10 14 38 AM](https://github.com/pyOpenSci/pyopensci.github.io/assets/5402633/44297a7b-a166-4df9-8c72-d9277773ec18)

### This PR

![Screenshot 2023-07-15 at 10 13 46 AM](https://github.com/pyOpenSci/pyopensci.github.io/assets/5402633/a7176c89-5156-48c2-b0a5-277efdb921be)