### PR TITLE
add update workflow for packages

### DIFF
--- a/.github/workflows/update-contribs.yml
+++ b/.github/workflows/update-contribs.yml
@@ -11,7 +11,8 @@ jobs:
     steps:
       - name: Check out the code
         uses: actions/checkout@v3
-      - uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
+      - name: Run update-web-metadata script
+        uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
         with:
           script_name_with_args: parse-contributors.py
       - name: Create Pull Request

--- a/.github/workflows/update-contribs.yml
+++ b/.github/workflows/update-contribs.yml
@@ -11,21 +11,9 @@ jobs:
     steps:
       - name: Check out the code
         uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v4
+      - uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
         with:
-          python-version: "3.10"
-      - name: Upgrade pip
-        run: |
-          # install pip=>20.1 to use "pip cache dir"
-          python -m pip install --upgrade pip wheel
-      - name: Install pyosmeta and run update contribs
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pip install pyosmeta@git+https://github.com/pyopensci/update-web-metadata
-          echo "$PWD"
-          python -b -W default scripts/parse-contributors.py
+          script_name_with_args: parse-contributors.py
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/update-contribs.yml
+++ b/.github/workflows/update-contribs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Run update-web-metadata script
         uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
         with:
-          script_name_with_args: parse-contributors.py
+          script_name_with_args: parse-contributors
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -14,7 +14,8 @@ jobs:
     steps:
       - name: Check out the code
         uses: actions/checkout@v3
-      - uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
+      - name: Run update-web-metadata script
+        uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
         with:
           script_name_with_args: parse_issue_metadata.py
       - name: Create Pull Request

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -9,15 +9,20 @@ on:
     # Runs on the first of each month (see https://crontab.guru)
     - cron: "* * 1 * *"
 jobs:
-  run-meta:
+  get-code:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the code
         uses: actions/checkout@v3
-      - name: Run update-web-metadata script
-        uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
-        with:
-          script_name_with_args: parse_issue_metadata.py
+  run-meta:
+    needs: get-code
+    uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
+    with:
+      script_name_with_args: parse_issue_metadata.py
+  send-pr:
+    runs-on: ubuntu-latest
+    needs: run-meta
+    steps:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -18,7 +18,7 @@ jobs:
     needs: get-code
     uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
     with:
-      script_name_with_args: parse_issue_metadata.py
+      script_name_with_args: parse-issue-metadata
   send-pr:
     runs-on: ubuntu-latest
     needs: run-meta

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -14,21 +14,9 @@ jobs:
     steps:
       - name: Check out the code
         uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v4
+      - uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
         with:
-          python-version: "3.10"
-      - name: Upgrade pip
-        run: |
-          # install pip=>20.1 to use "pip cache dir"
-          python -m pip install --upgrade pip wheel
-      - name: Install pyosmeta and run update packages
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pip install pyosmeta@git+https://github.com/pyopensci/update-web-metadata
-          echo "$PWD"
-          python -b -W default scripts/parse_issue_metadata.py
+          script_name_with_args: parse_issue_metadata.py
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -18,7 +18,7 @@ jobs:
     needs: get-code
     uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
     with:
-      script_name_with_args: parse-issue-metadata
+      script_name_with_args: parse-review-issues
   send-pr:
     runs-on: ubuntu-latest
     needs: run-meta


### PR DESCRIPTION
depends on https://github.com/pyOpenSci/update-web-metadata/pull/40

Simplifies our usage of update-web-metadata scripts by offloading setup steps to that repo.