### PR TITLE
CI Fixes circleci blog generation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,7 +5,7 @@ main:
     sub-nav:
       - title: "About peer review"
         icon:
-        url: "/about-peer-review/"
+        url: "/about-peer-review/index.html"
       - title: "Peer review guide"
         url: "https://www.pyopensci.org/software-peer-review/"
         icon: "fas fa-external-link-alt"
@@ -14,15 +14,15 @@ main:
         icon: "fas fa-external-link-alt"
   - title: "Our packages"
     icon: "fas fa-fw fa-envelope-square"
-    url: "/python-packages/"
+    url: "/python-packages/index.html"
   - title: "Blog"
-    url: /blog/
+    url: "/blog/index.html"
   # - title: "Resources"
   #   url: /resources/
   - title: "Community"
     sub-nav:
       - title: "Our Community"
-        url: "/our-community/"
+        url: "/our-community/index.html"
       - title: "Governance"
         icon: "fas fa-external-link-alt"
         url: "https://www.pyopensci.org/governance/"

--- a/_includes/archive-cards.html
+++ b/_includes/archive-cards.html
@@ -1,8 +1,8 @@
 <article>
-<a href="{{ post.url}}">
+<a href="{{ post.url | relative_url l}}">
 <div class="cards">
     {% if post.feature_img %}
-    <img src="{{ post.feature_img }}" alt="{{ post.feature_alt }}">
+    <img src="{{ post.feature_img | relative_url }}" alt="{{ post.feature_alt }}">
     {% endif %}
 
     <div class="card__bkg">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -31,4 +31,4 @@
   <script src="https://code.jquery.com/jquery-3.6.1.min.js" integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ=" crossorigin="anonymous"></script>
   <script src="https://npmcdn.com/isotope-layout@3/dist/isotope.pkgd.js"></script>
   <script src="https://npmcdn.com/imagesloaded@4/imagesloaded.pkgd.js"></script>
-  <script src="/assets/js/dropdown.js"></script>
+  <script src="{{ '/assets/js/dropdown.js' | relative_url }}"></script>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -21,7 +21,7 @@
                 <ul class="dropdown-content">
                   {% for subnav in alink.sub-nav %}
                   <li>
-                    <a href="{{ subnav.url }}" class="masthead__menu-item hover-underline">{{ subnav.title }}
+                    <a href="{{ subnav.url | relative_url }}" class="masthead__menu-item hover-underline">{{ subnav.title }}
                       {% if subnav.icon %} <i class="{{ subnav.icon }}"></i> {% endif %}
                     </a>
                   </li>


### PR DESCRIPTION
Follow up to https://github.com/pyOpenSci/pyopensci.github.io/pull/228. This PR fixes the CircleCI such that the links work. Overall, `relative_url` needs to be added to make sure that the base url is inserted correctly.

I'm unsure about having `index.html` added in `_data/navigation.yml`. CircleCI requires the `index.html` for the build to work. I can try to dynamically add the `index.html` just for PRs and leave it alone when the website is built on `main`.