### PR TITLE
CI Ignore contributor webites in htmlproofer

### DIFF
--- a/_includes/people-grid.html
+++ b/_includes/people-grid.html
@@ -31,7 +31,7 @@
       </a>
       {% endif %}
       {% if aperson.website %}
-      <a href="{{ aperson.website }}"><span class="fa-solid fa-blog" title="Click to view {{ aperson.title }}'s Website"></span>
+      <a href="{{ aperson.website }}" data-proofer-ignore><span class="fa-solid fa-blog" title="Click to view {{ aperson.title }}'s Website"></span>
       </a>
       {% endif %}
       {% if aperson.orcidid %}


### PR DESCRIPTION
This PR allows the contributor websites to not require `https` to pass the httlproofer in the CI.