### PR TITLE
CI Enable CircleCI redirector for PRs

### DIFF
--- a/.github/workflows/circleci-artifact-redirector.yml
+++ b/.github/workflows/circleci-artifact-redirector.yml
@@ -1,0 +1,31 @@
+name: CircleCI artifacts redirector
+on: [status]
+
+# Restrict the permissions granted to the use of secrets.GITHUB_TOKEN in this
+# github actions workflow:
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+permissions:
+  statuses: write
+
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    # For testing this action on a fork, remove the "github.repository =="" condition.
+    if: "github.repository == 'pyOpenSci/pyopensci.github.io' && github.event.context == 'ci/circleci: build'"
+    permissions:
+      statuses: write
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        id: step1
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_TOKEN }}
+          artifact-path: 0/_site/index.html
+          circleci-jobs: build
+          job-title: Check the rendered docs here!
+      - name: Check the URL
+        if: github.event.status != 'pending'
+        run: |
+          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA


### PR DESCRIPTION
This PR adds the workflow enables a redirector so that there is a link to the rendered docs in PRs. An admin still needs to add the `CIRCLECI_TOKEN` token to the secrets. The instructions are available in [redirector docs](https://github.com/larsoner/circleci-artifacts-redirector-action#example-usage):

> The api-token needs to be a [CircleCI personal API token](https://app.circleci.com/settings/user/tokens) (not a project token as it is not supported yet in API v2!)