### PR TITLE
Add md files for redirects from broken links

### DIFF
--- a/_pages/redirects/about.md
+++ b/_pages/redirects/about.md
@@ -1,0 +1,8 @@
+---
+title: About pyOpenSci
+permalink: /get-started/about-pyopensci
+redirect_to: https://www.pyopensci.org/
+---
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/community/contributors.md
+++ b/_pages/redirects/community/contributors.md
@@ -1,0 +1,8 @@
+---
+title: pyOpenSci Team & Contributors
+permalink: /contributors/.
+redirect_to: https://www.pyopensci.org/our-community/
+---
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/community/contributors.md
+++ b/_pages/redirects/community/contributors.md
@@ -1,6 +1,6 @@
 ---
 title: pyOpenSci Team & Contributors
-permalink: /contributors/.
+permalink: /contributors/
 redirect_to: https://www.pyopensci.org/our-community/
 ---
 

--- a/_pages/redirects/governance/coc.md
+++ b/_pages/redirects/governance/coc.md
@@ -1,0 +1,8 @@
+---
+title: pyOpenSci Community Code of Conduct
+permalink: /dev_guide/peer_review/coc.html
+redirect_to: https://www.pyopensci.org/governance/CODE_OF_CONDUCT.html
+---
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/peer-review-guide/glossary.md
+++ b/_pages/redirects/peer-review-guide/glossary.md
@@ -1,0 +1,8 @@
+---
+title: pyOpenSci Glossary
+permalink: /contributing-guide/appendices/glossary.html
+redirect_to: https://www.pyopensci.org/software-peer-review/appendices/glossary.html
+---
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/redirects/python-package-guide/contributing-file.md
+++ b/_pages/redirects/python-package-guide/contributing-file.md
@@ -1,0 +1,8 @@
+---
+title: pyOpenSci Contributing File
+permalink: /python-package-guide/documentation/contributing.html
+redirect_to: https://www.pyopensci.org/python-package-guide/documentation/repository-files/contributing-file.html
+---
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>


### PR DESCRIPTION
I set the general About to redirect to the main landing page, since there was no obvious replacement. Let me know if you want it to go elsewhere!