### PR TITLE
CI Remove the URL check in the artifact redirector

### DIFF
--- a/.github/workflows/circleci-artifact-redirector.yml
+++ b/.github/workflows/circleci-artifact-redirector.yml
@@ -25,7 +25,3 @@ jobs:
           artifact-path: 0/_site/index.html
           circleci-jobs: build
           job-title: Check the rendered docs here!
-      - name: Check the URL
-        if: github.event.status != 'pending'
-        run: |
-          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA


### PR DESCRIPTION
The redirector workflow is failing because of the [URL check](https://github.com/pyOpenSci/pyopensci.github.io/actions/workflows/circleci-artifact-redirector.yml
)

In our case, we need to check it.