### PR TITLE
Reinstate old working job

### DIFF
--- a/.github/workflows/update-contribs-reviews.yml
+++ b/.github/workflows/update-contribs-reviews.yml
@@ -1,7 +1,8 @@
-name: Update Contributors
+name: Update Contribs & reviewers
 
 on:
   push:
+    - *
   workflow_dispatch:
   schedule:
     # Runs on the first of each month (see https://crontab.guru)

--- a/.github/workflows/update-contribs-reviews.yml
+++ b/.github/workflows/update-contribs-reviews.yml
@@ -1,0 +1,48 @@
+name: Update Contributors
+
+on:
+  push:
+    branches:
+      - fix-workflows
+  workflow_dispatch:
+  schedule:
+    # Runs on the first of each month (see https://crontab.guru)
+    - cron: "* * 1 * *"
+jobs:
+  run-meta:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Upgrade pip
+        run: |
+          # install pip=>20.1 to use "pip cache dir"
+          python -m pip install --upgrade pip wheel
+      - name: Install pyosmeta and run update contribs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pip install pyosmeta@git+https://github.com/pyopensci/update-web-metadata
+          update-contributors
+          update-reviews
+          update-reviewers
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          add-paths: |
+            _data/contributors.yml
+            _data/packages.yml
+          author: Leah <leah@pyopensci.org>
+          base: main
+          branch: contribs
+          commit-message: "Update: Contributor & review file update"
+          delete-branch: true
+          title: Update contributor and review data
+        env:
+          # Custom token needed to trigger PR checks, as GITHUB_TOKEN won't
+          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+          GITHUB_TOKEN: ${{ secrets.PYOS_PR_TOKEN }}

--- a/.github/workflows/update-contribs-reviews.yml
+++ b/.github/workflows/update-contribs-reviews.yml
@@ -1,9 +1,9 @@
 name: Update Contribs & reviewers
 
 on:
-  push:
+  pull_request:
     branches:
-      - *
+      - '*'
   workflow_dispatch:
   schedule:
     # Runs on the first of each month (see https://crontab.guru)

--- a/.github/workflows/update-contribs-reviews.yml
+++ b/.github/workflows/update-contribs-reviews.yml
@@ -1,7 +1,7 @@
 name: Update Contributors
 
 on:
-  push
+  push:
   workflow_dispatch:
   schedule:
     # Runs on the first of each month (see https://crontab.guru)

--- a/.github/workflows/update-contribs-reviews.yml
+++ b/.github/workflows/update-contribs-reviews.yml
@@ -1,9 +1,7 @@
 name: Update Contributors
 
 on:
-  push:
-    branches:
-      - fix-workflows
+  push
   workflow_dispatch:
   schedule:
     # Runs on the first of each month (see https://crontab.guru)

--- a/.github/workflows/update-contribs-reviews.yml
+++ b/.github/workflows/update-contribs-reviews.yml
@@ -2,7 +2,8 @@ name: Update Contribs & reviewers
 
 on:
   push:
-    - *
+    branches:
+      - *
   workflow_dispatch:
   schedule:
     # Runs on the first of each month (see https://crontab.guru)

--- a/.github/workflows/update-contribs.yml
+++ b/.github/workflows/update-contribs.yml
@@ -1,31 +1,31 @@
-name: Update Contributors
+# name: Update Contributors
 
-on:
-  workflow_dispatch:
-  schedule:
-    # Runs on the first of each month (see https://crontab.guru)
-    - cron: "* * 1 * *"
-jobs:
-  run-meta:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the code
-        uses: actions/checkout@v3
-      - name: Run update-web-metadata script
-        uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
-        with:
-          script_name_with_args: parse-contributors
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
-        with:
-          add-paths: _data/contributors.yml
-          author: Leah <leah@pyopensci.org>
-          base: main
-          branch: contribs
-          commit-message: "Update: Contributor file update"
-          delete-branch: true
-          title: Update new contributors
-        env:
-          # Custom token needed to trigger PR checks, as GITHUB_TOKEN won't
-          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
-          GITHUB_TOKEN: ${{ secrets.PYOS_PR_TOKEN }}
+# on:
+#   workflow_dispatch:
+#   schedule:
+#     # Runs on the first of each month (see https://crontab.guru)
+#     - cron: "* * 1 * *"
+# jobs:
+#   run-meta:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Check out the code
+#         uses: actions/checkout@v3
+#       - name: Run update-web-metadata script
+#         uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
+#         with:
+#           script_name_with_args: parse-contributors
+#       - name: Create Pull Request
+#         uses: peter-evans/create-pull-request@v5
+#         with:
+#           add-paths: _data/contributors.yml
+#           author: Leah <leah@pyopensci.org>
+#           base: main
+#           branch: contribs
+#           commit-message: "Update: Contributor file update"
+#           delete-branch: true
+#           title: Update new contributors
+#         env:
+#           # Custom token needed to trigger PR checks, as GITHUB_TOKEN won't
+#           # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+#           GITHUB_TOKEN: ${{ secrets.PYOS_PR_TOKEN }}

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -1,39 +1,39 @@
-name: Update Packages
+# name: Update Packages
 
-on:
-  workflow_dispatch:
-  push:
-    branches:
-      - 'ci-update-packages-yml'
-  schedule:
-    # Runs on the first of each month (see https://crontab.guru)
-    - cron: "* * 1 * *"
-jobs:
-  get-code:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the code
-        uses: actions/checkout@v3
-  run-meta:
-    needs: get-code
-    uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
-    with:
-      script_name_with_args: parse-review-issues
-  send-pr:
-    runs-on: ubuntu-latest
-    needs: run-meta
-    steps:
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
-        with:
-          add-paths: _data/packages.yml
-          author: Leah <leah@pyopensci.org>
-          base: main
-          branch: packages-update
-          commit-message: "Update: Package file update"
-          delete-branch: true
-          title: Update new packages
-        env:
-          # Custom token needed to trigger PR checks, as GITHUB_TOKEN won't
-          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
-          GITHUB_TOKEN: ${{ secrets.PYOS_PR_TOKEN }}
+# on:
+#   workflow_dispatch:
+#   push:
+#     branches:
+#       - 'ci-update-packages-yml'
+#   schedule:
+#     # Runs on the first of each month (see https://crontab.guru)
+#     - cron: "* * 1 * *"
+# jobs:
+#   get-code:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Check out the code
+#         uses: actions/checkout@v3
+#   run-meta:
+#     needs: get-code
+#     uses: pyOpenSci/update-web-metadata/.github/workflows/run-script.yml@main
+#     with:
+#       script_name_with_args: parse-review-issues
+#   send-pr:
+#     runs-on: ubuntu-latest
+#     needs: run-meta
+#     steps:
+#       - name: Create Pull Request
+#         uses: peter-evans/create-pull-request@v5
+#         with:
+#           add-paths: _data/packages.yml
+#           author: Leah <leah@pyopensci.org>
+#           base: main
+#           branch: packages-update
+#           commit-message: "Update: Package file update"
+#           delete-branch: true
+#           title: Update new packages
+#         env:
+#           # Custom token needed to trigger PR checks, as GITHUB_TOKEN won't
+#           # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+#           GITHUB_TOKEN: ${{ secrets.PYOS_PR_TOKEN }}


### PR DESCRIPTION
This is an attempt to reinstate the old working workflow for now - just so i can keep updating data without local file moving shenanigans .

it creates a new workflow that installs pyosmeta and runs the three entry point scripts
it then creates a pr.
it also comments out the other two broken workflows just for now. we can always implement reusable workflows in the future but this will keep us running for the time being. 