### PR TITLE
Fix: run pre-commit in action

### DIFF
--- a/.github/workflows/circleci-artifact-redirector.yml
+++ b/.github/workflows/circleci-artifact-redirector.yml
@@ -24,4 +24,4 @@ jobs:
           api-token: ${{ secrets.CIRCLECI_TOKEN }}
           artifact-path: 0/_site/index.html
           circleci-jobs: build
-          job-title: Check the rendered docs here!
+          job-title: Check the rendered website build here!

--- a/.github/workflows/update-contribs-reviews.yml
+++ b/.github/workflows/update-contribs-reviews.yml
@@ -27,6 +27,11 @@ jobs:
           update-contributors
           update-reviews
           update-review-teams
+
+      - name: run precommit hooks
+        uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: pre-commit run --all-files
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
This fix should run precommit on the contrib update build saving us a manual step of triggering it. 