### PR TITLE
Fix astartes repository link

### DIFF
--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -8,7 +8,7 @@
       name: Kevin Spiekermann
     - github_username: himaghna
       name:
-  repository_link: GitHub
+  repository_link: https://github.com/jacksonburns/astartes
   version_submitted: v[1.1.2](https://github.com/JacksonBurns/astartes/releases/tag/v1.1.2)
   categories:
     - data-processing/munging


### PR DESCRIPTION
I noticed the astartes went to a 404 page, I think this is the correct place to fix it but not 100%, feel free to close if incorrect.