### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# CODEOWNERS file sets rules for who should be notified when a pull request
+# modifies code in a specific path.
+
+# Configuration parameters for site
+_config.yml                  @lwasser @kierisi
+
+# Workflow files for GitHub Actions
+.github/**                   @lwasser @willingc
+
+# Site pages
+_site/*                      @lwasser @kierisi
+
+# Blog posts
+_posts/*                     @lwasser @kierisi
+
+# Scripts
+scripts/*                    @lwasser @willingc

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # CODEOWNERS file sets rules for who should be notified when a pull request
 # modifies code in a specific path.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners for more information.
 
 # Configuration parameters for site
 _config.yml                  @lwasser @kierisi

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 
 # Configuration parameters for site
 _config.yml                  @lwasser @kierisi
+CNAME                        @lwasser @kierisi
 
 # Workflow files for GitHub Actions
 .github/**                   @lwasser @willingc


### PR DESCRIPTION
This PR adds a CODEOWNERS file. This file helps prevent accidental changes to key files or directories.

If a PR is opened with changes to a listed file or directory, the listed maintainers will be made reviewers of the PR.