### PR TITLE
Fix: link to community partners

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -27,7 +27,7 @@ peer-review:
     alt: "Light purple image with a bunch from different backgrounds of stick figure people in a slightly darker color. The text on the image at the top says Community Partnerships"
     title: "Community Partnerships"
     excerpt: "We partner with domain-specific scientific Python communities such as [Pangeo](https://www.pyopensci.org/software-peer-review/partners/pangeo.html) who want to review affiliated packages. Through this collaboration, we develop community-specific standards that are used in our reviews to evaluate whether a package meets affiliation requirements. This removes the need for communities to develop their own peer review process."
-    url: https://www.pyopensci.org/software-peer-review/partners/scientific-communities.html
+    url: https://www.pyopensci.org/partners.html
     btn_label: "> Learn More About Our Community Partners"
     btn_class: btn--inverse
   - image_path: images/python-packaging-guide.png


### PR DESCRIPTION
This is just a link fix /update

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206125155258707