### PR TITLE
[for review] updated volunteer page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -20,8 +20,6 @@ main:
     url: "/python-packages/index.html"
   - title: "Blog"
     url: "/blog/index.html"
-  # - title: "Resources"
-  #   url: /resources/
   - title: "Community"
     sub-nav:
       - title: "Our Community"
@@ -33,4 +31,6 @@ main:
         icon: "fas fa-external-link-alt"
         url: "https://www.pyopensci.org/governance/"
   - title: "Get Involved"
-    url: /get-involved-contact.html
+    sub-nav:
+      - title: "Volunteer"
+        url: "/volunteer.html"

--- a/_pages/redirects/community/get-involved-contact.md
+++ b/_pages/redirects/community/get-involved-contact.md
@@ -1,0 +1,8 @@
+---
+title: Old Get involved page redirect
+permalink: get-involved-contact.html
+redirect_to: https://www.pyopensci.org/volunteer.html
+---
+
+Oops - looks like you're looking for our {{ page.title }}. Directing you
+to the right page now: <a href="{{ page.redirect_to }}"> {{ page.redirect_to }} </a>

--- a/_pages/volunteer.md
+++ b/_pages/volunteer.md
@@ -84,7 +84,7 @@ There are many ways to get involved with pyOpenSci! We’re always looking for f
 
 ## Share your expertise and experience with the broader community through blogging
 
-And last but not least, we’d also love for you to be a guest blogger on the [pyOpenSci blog](https://www.pyopensci.org/blog/index.html)! If you’d like to write about a pyOpenSci package, your experiences with pyOpenSci, or how you’re using free and open Python tools in your scientific endeavors, we’d love to hear from you! Email our Community team at [media@pyopensci.org](media@pyopensci.org) for more information.
+And last but not least, we’d also love for you to be a guest blogger on the [pyOpenSci blog](https://www.pyopensci.org/blog/index.html)! If you’d like to write about a pyOpenSci package, your experiences with pyOpenSci, or how you’re using free and open Python tools in your scientific endeavors, we’d love to hear from you! Email our Community team at [media@pyopensci.org](mailto:media@pyopensci.org) for more information.
 
 ## Learn more about volunteering with pyOpenSci
 

--- a/_pages/volunteer.md
+++ b/_pages/volunteer.md
@@ -88,7 +88,7 @@ And last but not least, we’d also love for you to be a guest blogger on the [p
 
 ## Learn more about volunteering with pyOpenSci
 
-If you still have questions about volunteer roles at pyOpenSci, email our Community team at [media@pyopensci.org](media@pyopensci.org), and we’d be more than happy to help! You can also ask questions and network with the broader pyOpenSci community on our [Discourse forum](https://pyopensci.discourse.group/).
+If you still have questions about volunteer roles at pyOpenSci, email our Community team at [media@pyopensci.org](mailto:media@pyopensci.org), and we’d be more than happy to help! You can also ask questions and network with the broader pyOpenSci community on our [Discourse forum](https://pyopensci.discourse.group/).
 
 </div>
 </div>

--- a/_pages/volunteer.md
+++ b/_pages/volunteer.md
@@ -1,10 +1,13 @@
 ---
 layout: splash
+classes: flowing
 title: "Get involved with pyOpenSci"
 author_profile: false
 published: true
 site-map: true
 permalink: /volunteer.html
+volunteer-mission:
+  - excerpt: "The vibrant and diverse pyOpenSci community is driven by volunteer Pythonistas that care deeply about the scientific Python open source software that drives open science."
 help-us:
   - image_path:
     title: "Lend a Hand on GitHub"
@@ -29,31 +32,70 @@ help-us:
     btn_class: btn--inverse
 ---
 
-## pyOpenSci volunteers come from diverse backgrounds  
+{% include feature_row id="volunteer-mission" type="center" %}
 
-The vibrant and diverse pyOpenSci community is driven by volunteer Pythonistas that care deeply about the scientific Python open source software that drives open science. Our volunteers come from a diverse array of backgrounds, including industry, academia, agencies, national labs, and more. pyOpenSci volunteers are primarily engaged in both the peer review process and developing resources to support the scientific Python community. Volunteers  help improve the quality, maintainability and usability of the software that scientists need for open science. They also support maintainers in developing scientific Python software.  
+<div class="pyos-section purple">
+<div class="content" markdown="1">
 
-## pyOpenSci volunteers build skills and community  
+## pyOpenSci volunteers come from diverse backgrounds
 
-When you volunteer with pyOpenSci, you’re not only giving back to the community, but also:  
+Our volunteers come from a diverse array of backgrounds, including industry, academia, agencies, national labs, and more. pyOpenSci volunteers are primarily engaged in both the peer review process and developing resources to support the scientific Python community. Volunteers  help improve the quality, maintainability and usability of the software that scientists need for open science. They also support maintainers in developing scientific Python software.
 
-- **Learning new skills:** you don’t have to be a Python expert to get involved with pyOpenSci. We can help you level up your packaging game and learn how to constructively review both code and copy through contributions to our online learning resources.   
-- **Connecting with peers:** our [public Discourse forum](https://pyopensci.discourse.group/) is a great place to ask and answer questions, as well as discuss packaging and open science with other Pythonistas.  
-- **Being recognized** on the [pyOpenSci website](https://www.pyopensci.org/our-community/index.html) and [GitHub repositories](https://github.com/pyOpenSci): your contribution matters, and we want to ensure your work is recognized and celebrated in a public forum.  
+</div>
+</div>
+
+{% include div_purple_bottom.html  %}
+
+
+<div class="pyos-section" markdown="1">
+<div class="content" markdown="1">
+
+## pyOpenSci volunteers build skills and community
+
+When you volunteer with pyOpenSci, you’re not only giving back to the community, but also:
+
+- **Learning new skills:** you don’t have to be a Python expert to get involved with pyOpenSci. We can help you level up your packaging game and learn how to constructively review both code and copy through contributions to our online learning resources.
+- **Connecting with peers:** our [public Discourse forum](https://pyopensci.discourse.group/) is a great place to ask and answer questions, as well as discuss packaging and open science with other Pythonistas.
+- **Being recognized** on the [pyOpenSci website](https://www.pyopensci.org/our-community/index.html) and [GitHub repositories](https://github.com/pyOpenSci): your contribution matters, and we want to ensure your work is recognized and celebrated in a public forum.
+
+</div>
+</div>
+
+{% include div_purple_top.html  %}
+
+<div class="pyos-section purple" markdown="1">
+<div class="content" markdown="1">
 
 ## Volunteer opportunities with pyOpenSci
 
-There are many ways to get involved with pyOpenSci! We’re always looking for folks to:  
+There are many ways to get involved with pyOpenSci! We’re always looking for folks to:
 
 {% include feature_row_pyos id="help-us" %}
 
-## Share your expertise and experience with the broader community through blogging  
 
-And last but not least, we’d also love for you to be a guest blogger on the [pyOpenSci blog](https://www.pyopensci.org/blog/index.html)! If you’d like to write about a pyOpenSci package, your experiences with pyOpenSci, or how you’re using free and open Python tools in your scientific endeavors, we’d love to hear from you! Email our Community team at [media@pyopensci.org](media@pyopensci.org) for more information.   
+</div>
+</div>
 
-## Learn more about volunteering with pyOpenSci  
+{% include div_purple_bottom.html  %}
 
-If you still have questions about volunteer roles at pyOpenSci, email our Community team at [media@pyopensci.org](media@pyopensci.org), and we’d be more than happy to help! You can also ask questions and network with the broader pyOpenSci community on our [Discourse forum](https://pyopensci.discourse.group/).  
+
+<div class="pyos-section" markdown="1">
+<div class="content" markdown="1">
+
+## Share your expertise and experience with the broader community through blogging
+
+And last but not least, we’d also love for you to be a guest blogger on the [pyOpenSci blog](https://www.pyopensci.org/blog/index.html)! If you’d like to write about a pyOpenSci package, your experiences with pyOpenSci, or how you’re using free and open Python tools in your scientific endeavors, we’d love to hear from you! Email our Community team at [media@pyopensci.org](media@pyopensci.org) for more information.
+
+## Learn more about volunteering with pyOpenSci
+
+If you still have questions about volunteer roles at pyOpenSci, email our Community team at [media@pyopensci.org](media@pyopensci.org), and we’d be more than happy to help! You can also ask questions and network with the broader pyOpenSci community on our [Discourse forum](https://pyopensci.discourse.group/).
+
+</div>
+</div>
+
+
+<div class="pyos-section purple" markdown="1">
+<div class="content" markdown="1">
 
 ## Let's connect!
 
@@ -63,35 +105,31 @@ If you still have questions about volunteer roles at pyOpenSci, email our Commun
 - [<i class="fa-brands fa-linkedin"></i> LinkedIn](https://www.linkedin.com/company/pyopensci)
 - [<i class="fa-brands fa-github"></i> GitHub](https://github.com/pyOpenSci)
 
-## Meet the PyOpenSci community contributors
+</div>
+</div>
 
-{: .clearall }
-{: .clearall }
 
-{% assign ppl_sorted = site.data.contributors | reverse %}
-{% assign total_people = ppl_sorted | size %}
+<div class="pyos-section" markdown="1">
+<div class="content" markdown="1">
+
+## Meet the most recent PyOpenSci community contributors
+
+<!-- Get a list of all contribs and sort reverse so newest are first -->
+{% assign new_ppl = site.data.contributors | reverse %}
+
+{% assign total_people = new_ppl | size %}
 
 pyOpenSci has a diverse and vibrant community of pythonistas! To date,
 **{{ total_people }}** wonderful people have contributed to pyOpenSci.
 
-<p><input type="text" id="quicksearch" placeholder="Search" /></p>
-
-<div id="filters" class="button-group">
-  <button class="button is-checked" data-filter="*">Show All</button>
-  <button class="button" data-filter=".leadership">Leadership</button>
-  <button class="button" data-filter=".editor">Editorial Team</button>
-  <button class="button" data-filter=".reviewer">Reviewers</button>
-  <button class="button" data-filter=".maintainer">Maintainers</button>
-  <button class="button" data-filter=".peer-review-guide">Peer Review Guide</button>
-  <button class="button" data-filter=".package-guide">Packaging Guide</button>
-  <button class="button" data-filter=".metrics-contrib">Metrics</button>
-  <button class="button" data-filter=".web-contrib">Website</button>
-
+<div class="entries-grid">
+{% for aperson in new_ppl limit:4 %}
+    {% include people-grid.html  %}
+{% endfor %}
 </div>
 
-<div class="grid-isotope">
- <div class="grid-sizer"></div>
-{% for aperson in ppl_sorted %}
-  {% include people-grid.html %}
-{% endfor %}
+<a href="/python-packages/" class="btn btn--info">View All Contributors <i class="fa fa-4 fa-arrow-circle-right" aria-hidden="true"></i></a>
+
+
+</div>
 </div>

--- a/_pages/volunteer.md
+++ b/_pages/volunteer.md
@@ -17,14 +17,14 @@ help-us:
     btn_label: "> Check out our GitHub Help Wanted Board"
     btn_class: btn--inverse
   - image_path:
-    title: "Sign up to be a package reviewer"
+    title: "Sign up to be a scientific Python package reviewer"
     alt:
     excerpt: "Finding reviewers is one of the more challenging parts of running a peer review process. We are always looking for new reviewers from a broad range of scientific domains. Some reviewers have extensive packaging expertise and others have domain expertise. We think that mix is great, so sign up today! If you are new to reviewing we are happy to support you through our peer review mentorship program."
     url: https://forms.gle/GHfxvmS47nQFDcBM6
     btn_label: "> Sign up now."
     btn_class: btn--inverse
   - image_path:
-    title: "Get involved as a peer review Editor"
+    title: "Get involved as software peer review Editor"
     alt:
     excerpt: "We also often recruit new editors to support our peer review process. Keep an eye out on our [Discourse forum](https://pyopensci.discourse.group/) for calls for new editors. In the meantime if you are interested in learning more about the editor role, check out our [peer review guidebook](https://www.pyopensci.org/software-peer-review/). "
     url: https://www.pyopensci.org/software-peer-review/how-to/editors-guide.html

--- a/_pages/volunteer.md
+++ b/_pages/volunteer.md
@@ -1,0 +1,97 @@
+---
+layout: splash
+title: "Get involved with pyOpenSci"
+author_profile: false
+published: true
+site-map: true
+permalink: /volunteer.html
+help-us:
+  - image_path:
+    title: "Lend a Hand on GitHub"
+    alt:
+    excerpt: "Got some time to help? Check out our GitHub Project Board for a list of current issues that we could use help with. Any issue that is tagged `help-wanted` in our repos is also fair game for anyone to tackle! We add anyone who contributes to pyOpenSci to our [community page](/our-community/). "
+    url: https://github.com/orgs/pyOpenSci/projects/3/views/1
+    btn_label: "> Check out our GitHub Help Wanted Board"
+    btn_class: btn--inverse
+  - image_path:
+    title: "Sign up to be a package reviewer"
+    alt:
+    excerpt: "Finding reviewers is one of the more challenging parts of running a peer review process. We are always looking for new reviewers from a broad range of scientific domains. Some reviewers have extensive packaging expertise and others have domain expertise. We think that mix is great, so sign up today! If you are new to reviewing we are happy to support you through our peer review mentorship program."
+    url: https://forms.gle/GHfxvmS47nQFDcBM6
+    btn_label: "> Sign up now."
+    btn_class: btn--inverse
+  - image_path:
+    title: "Get involved as a peer review Editor"
+    alt:
+    excerpt: "We also often recruit new editors to support our peer review process. Keep an eye out on our [Discourse forum](https://pyopensci.discourse.group/) for calls for new editors. In the meantime if you are interested in learning more about the editor role, check out our [peer review guidebook](https://www.pyopensci.org/software-peer-review/). "
+    url: https://www.pyopensci.org/software-peer-review/how-to/editors-guide.html
+    btn_label: "> Click here to learn more about the editor role."
+    btn_class: btn--inverse
+---
+
+## pyOpenSci volunteers come from diverse backgrounds  
+
+The vibrant and diverse pyOpenSci community is driven by volunteer Pythonistas that care deeply about the scientific Python open source software that drives open science. Our volunteers come from a diverse array of backgrounds, including industry, academia, agencies, national labs, and more. pyOpenSci volunteers are primarily engaged in both the peer review process and developing resources to support the scientific Python community. Volunteers  help improve the quality, maintainability and usability of the software that scientists need for open science. They also support maintainers in developing scientific Python software.  
+
+## pyOpenSci volunteers build skills and community  
+
+When you volunteer with pyOpenSci, you’re not only giving back to the community, but also:  
+
+- **Learning new skills:** you don’t have to be a Python expert to get involved with pyOpenSci. We can help you level up your packaging game and learn how to constructively review both code and copy through contributions to our online learning resources.   
+- **Connecting with peers:** our [public Discourse forum](https://pyopensci.discourse.group/) is a great place to ask and answer questions, as well as discuss packaging and open science with other Pythonistas.  
+- **Being recognized** on the [pyOpenSci website](https://www.pyopensci.org/our-community/index.html) and [GitHub repositories](https://github.com/pyOpenSci): your contribution matters, and we want to ensure your work is recognized and celebrated in a public forum.  
+
+## Volunteer opportunities with pyOpenSci
+
+There are many ways to get involved with pyOpenSci! We’re always looking for folks to:  
+
+{% include feature_row_pyos id="help-us" %}
+
+## Share your expertise and experience with the broader community through blogging  
+
+And last but not least, we’d also love for you to be a guest blogger on the [pyOpenSci blog](https://www.pyopensci.org/blog/index.html)! If you’d like to write about a pyOpenSci package, your experiences with pyOpenSci, or how you’re using free and open Python tools in your scientific endeavors, we’d love to hear from you! Email our Community team at [media@pyopensci.org](media@pyopensci.org) for more information.   
+
+## Learn more about volunteering with pyOpenSci  
+
+If you still have questions about volunteer roles at pyOpenSci, email our Community team at [media@pyopensci.org](media@pyopensci.org), and we’d be more than happy to help! You can also ask questions and network with the broader pyOpenSci community on our [Discourse forum](https://pyopensci.discourse.group/).  
+
+## Let's connect!
+
+- [<i class="fa-brands fa-discourse"></i> Discourse](https://pyopensci.discourse.group/)
+- [<i class="fa-brands fa-mastodon"></i> Mastodon](https://fosstodon.org/@pyopensci)
+- [<i class="fa-solid fa-cloud"></i> Bluesky](https://bsky.app/profile/pyopensci.bsky.social)
+- [<i class="fa-brands fa-linkedin"></i> LinkedIn](https://www.linkedin.com/company/pyopensci)
+- [<i class="fa-brands fa-github"></i> GitHub](https://github.com/pyOpenSci)
+
+## Meet the PyOpenSci community contributors
+
+{: .clearall }
+{: .clearall }
+
+{% assign ppl_sorted = site.data.contributors | reverse %}
+{% assign total_people = ppl_sorted | size %}
+
+pyOpenSci has a diverse and vibrant community of pythonistas! To date,
+**{{ total_people }}** wonderful people have contributed to pyOpenSci.
+
+<p><input type="text" id="quicksearch" placeholder="Search" /></p>
+
+<div id="filters" class="button-group">
+  <button class="button is-checked" data-filter="*">Show All</button>
+  <button class="button" data-filter=".leadership">Leadership</button>
+  <button class="button" data-filter=".editor">Editorial Team</button>
+  <button class="button" data-filter=".reviewer">Reviewers</button>
+  <button class="button" data-filter=".maintainer">Maintainers</button>
+  <button class="button" data-filter=".peer-review-guide">Peer Review Guide</button>
+  <button class="button" data-filter=".package-guide">Packaging Guide</button>
+  <button class="button" data-filter=".metrics-contrib">Metrics</button>
+  <button class="button" data-filter=".web-contrib">Website</button>
+
+</div>
+
+<div class="grid-isotope">
+ <div class="grid-sizer"></div>
+{% for aperson in ppl_sorted %}
+  {% include people-grid.html %}
+{% endfor %}
+</div>


### PR DESCRIPTION
I've created a new volunteer page (/volunteer.html) based on the copy reviewed in our planning document. The copy should be good, although I didn't do any design work. 

Items that will need to be addressed:
- [ ] adding this page to the main headers//sitemap 
- [ ] any design enhancements
- [ ] deleting//deprecating existing [volunteer page](https://www.pyopensci.org/get-involved-contact.html)

Of note - there is information on the existing volunteer page that isn't on this one. I believe it's accounted for in our updated site map!

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206250007056589