### PR TITLE
Fix narrow overlay for close button

### DIFF
--- a/_sass/minimal-mistakes/_pyos-dropdown.scss
+++ b/_sass/minimal-mistakes/_pyos-dropdown.scss
@@ -338,7 +338,9 @@ drop shadow
     display: block;
     position: absolute;
     top: 5%;
-    right: 5%;}
+    right: 5%;
+    width: 2.0rem;
+  }
 
   .burger__icon, burger__icon::before, burger__icon::after {
     display: block; }


### PR DESCRIPTION
This pull request fixes the overlay of the close button for narrow screens.
Related to #208.

The close button moves from ![closebefore](https://github.com/pyOpenSci/pyopensci.github.io/assets/1662261/e06044e8-22bc-4ec2-9cb6-693c7233cf2d) to ![closeafter](https://github.com/pyOpenSci/pyopensci.github.io/assets/1662261/df804190-6477-4b11-8ec8-0f2469acac62)

Is this acceptable?

