### PR TITLE
Fix: build fails without image id

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -5542,7 +5542,7 @@
   email: carlosramosca@hotmail.com
 - name: Derek Homeier
   github_username: dhomeier
-  github_image_id:
+  github_image_id: 709020
   title:
   sort: 1
   bio:


### PR DESCRIPTION
i added derek manually but the image id was missing. this causes a failure in our build as gh username and image id are core metadata needed to find a user