### PR TITLE
pin htmlproofer version

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Use GitHub Actions' cache to shorten build times and decrease load on servers
       - name: Use cache to shorten build time
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -29,7 +29,7 @@ jobs:
           build_dir: _site
 
       - name: Check HTML using htmlproofer
-        uses: chabad360/htmlproofer@master
+        uses: chabad360/htmlproofer@v2
         with:
           directory: "_site"
           arguments: |

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 gem "github-pages", group: :jekyll_plugins
 gem "jekyll-include-cache"
 gem "webrick"
-gem "html-proofer"
+gem "html-proofer", "~> 3.0"


### PR DESCRIPTION
This PR makes the following changes:
- Pins html-proofer action to v2 instead of master
- Bumps actions to v4 to use node 20 instead of deprecated node 16
- Add version to gemfile for htmlproofer. See https://talk.jekyllrb.com/t/htmlproofer-fails-on-encoding-error/8763/5