### PR TITLE
add lychee action

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -53,6 +53,14 @@ jobs:
           path: tmp/.htmlproofer
           key: ${{ runner.os }}-htmlproofer
 
+      - name: Check links with lychee
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.9.0
+        with:
+          args: --verbose --no-progress _site/**/*.html
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
       - name: Run htmlproofer
         run: |
           ruby scripts/htmlproofer.rb

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,6 @@
+https://github.com/*
+https://fonts.googleapis.com/*
+https://fonts.gstatic.com/*
+https://www.linkedin.com/*
+https://www.youtube-nocookie.com/*
+https://t.co/*


### PR DESCRIPTION
This PR adds [lychee](https://lychee.cli.rs/) (a Rust based link checker) to run just before the HTMLProofer. Lychee only takes about 15 sec to check all of the links. It will be a good check that htmlproofer is working as expected with the links.