### PR TITLE
Update link check action to test weekly

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,24 +1,28 @@
-name: Links
+name: Link check (weekly)
 
 on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    - cron: "10 02 * * *"
+    - cron: "10 02 * * 6"
 
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v1.9.0
+        with:
+          args: --verbose --no-progress _site/*.html
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@v5
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md


### PR DESCRIPTION
This changes the cron action to weekly and bumps action versions to avoid deprecated Node 16.