### PR TITLE
fix the https not found warning

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -5,7 +5,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Itim&family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet" async>
 
 <!-- Matomo -->
-<script>
+<script type="text/javascript">
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
   _paq.push(['trackPageView']);
@@ -15,11 +15,9 @@
     _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '2']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src='//cdn.matomo.cloud/pyopensci.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.src='https://cdn.matomo.cloud/pyopensci.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
 <!-- End Matomo Code -->
-
-
 
 <!-- END custom head content-->


### PR DESCRIPTION
This PR corrects links that were flagged in the lighthouse mobile test run locally. 
<img width="1174" alt="Screenshot 2024-04-05 at 2 31 16 PM" src="https://github.com/pyOpenSci/pyopensci.github.io/assets/2680980/51bccb2f-f700-4db8-89dc-9ebb5215cb33">

After merging this, we should check that matomo collection is working as expected.