### PR TITLE
Change footer text color slightly to be greater contrast > 4.5

### DIFF
--- a/_posts/2024-03-01-pyos-newsletter-march-2024.md
+++ b/_posts/2024-03-01-pyos-newsletter-march-2024.md
@@ -29,7 +29,7 @@ pyOpenSci has officially partnered with the [AstroPy Project](https://www.astrop
 
 [sunPy](https://sunpy.org/), a Python package that provides fundamental tools for accessing, loading, and interacting with solar physics data in Python, has successfully gone through the pyOpenSci open peer review process, which is the first step in our budding partnership with the heliophysics community!
 
-You can read more about sunPy and pyOpenSci in [this lovely blog post](https://sunpy.org/posts/2024/2024-01-24-pyopensci) from Nabil Friej.
+You can read more about sunPy and pyOpenSci in [this lovely blog post](https://sunpy.org/posts/2024/2024-01-24-pyopensci.html) from Nabil Friej.
 
 ## <i class="fa-regular fa-face-smile"></i> Say hi to sciform
 

--- a/_sass/minimal-mistakes/_footer.scss
+++ b/_sass/minimal-mistakes/_footer.scss
@@ -9,7 +9,7 @@
   margin-right: 0;
   width: 100%;
   margin-top: 3em;
-  color: #6c666d;
+  color: $muted-text-color;
   -webkit-animation: $intro-transition;
   animation: $intro-transition;
   -webkit-animation-delay: 0.45s;
@@ -42,7 +42,7 @@
   .fab,
   .far,
   .fal {
-    color: #6c666d;
+    color: $muted-text-color;
   }
 }
 

--- a/_sass/minimal-mistakes/_footer.scss
+++ b/_sass/minimal-mistakes/_footer.scss
@@ -9,7 +9,7 @@
   margin-right: 0;
   width: 100%;
   margin-top: 3em;
-  color: $muted-text-color;
+  color: #6c666d;
   -webkit-animation: $intro-transition;
   animation: $intro-transition;
   -webkit-animation-delay: 0.45s;
@@ -42,7 +42,7 @@
   .fab,
   .far,
   .fal {
-    color: $muted-text-color;
+    color: #6c666d;
   }
 }
 

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -89,7 +89,7 @@ $background-color: #fff !default;
 $code-background-color: #fafafa !default;
 $code-background-color-dark: $light-gray !default;
 $text-color: $dark-gray !default;
-$muted-text-color: mix(#fff, $text-color, 20%) !default;
+$muted-text-color: mix(#fff, $text-color, 25%) !default;
 $border-color: $lighter-gray !default;
 $form-background-color: $lighter-gray !default;
 $footer-background-color: $lighter-gray !default;

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -89,7 +89,7 @@ $background-color: #fff !default;
 $code-background-color: #fafafa !default;
 $code-background-color-dark: $light-gray !default;
 $text-color: $dark-gray !default;
-$muted-text-color: mix(#fff, $text-color, 25%) !default;
+$muted-text-color: mix(#fff, $text-color, 18%) !default;
 $border-color: $lighter-gray !default;
 $form-background-color: $lighter-gray !default;
 $footer-background-color: $lighter-gray !default;


### PR DESCRIPTION
This changes the footer text color slightly for accessibility.

The calculated `$muted-text-color` was used in places other than the footer so overriding in the footer made sense.
<img width="745" alt="Screenshot 2024-04-05 at 3 06 12 PM" src="https://github.com/pyOpenSci/pyopensci.github.io/assets/2680980/be4fc932-672d-4dbb-9d40-8b829f70d9dc">
 