### PR TITLE
Add GitHub Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,9 +33,6 @@ If applicable, add screenshots to help explain your problem.
  - Browser [e.g., stock browser, safari]
 
 **System/Environment (if issue was encountered while making a contribution to this repository):**
-- System CPU: [e.g., (8) x64 Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz]
-- System memory: [e.g., 16 GB]
-- Shell: [e.g., bash]
 - Ruby version: [e.g., 3.3.1]
 - Output of `gem list`: [paste as a [code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)]
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 'BUG: (Please describe your issue)'
+labels: 'bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (if issue was encountered on a desktop):**
+ - OS with version: [e.g., macOS Sonoma 14.5]
+ - Browser [e.g., chrome, safari]
+
+**Mobile (if issue was encountered on a mobile device):**
+ - Device: [e.g., iPhone 15 Pro]
+ - OS with version: [e.g., iOS 17.5.1]
+ - Browser [e.g., stock browser, safari]
+
+**System/Environment (if issue was encountered while making a contribution to this repository):**
+- System CPU: [e.g., (8) x64 Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz]
+- System memory: [e.g., 16 GB]
+- Shell: [e.g., bash]
+- Ruby version: [e.g., 3.3.1]
+- Output of `gem list`: [paste as a [code block](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Ask a question
+    url: https://github.com/pyOpenSci/pyopensci.github.io/discussions
+    about: Ask questions and discuss with other community members

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: 'FEATURE: (Please summarize your feature request)'
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Add an initial set of GitHub Issue templates for "Bug report", "Feature request", and "Ask a question" (link to Discussions). This also permits blank issues to be created.

Feel free to revise any of the templates (including wording) as needed!

Closes #124.