### PR TITLE
Fix: tell htmlproofer to ignore broken links

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -53,4 +53,4 @@ jobs:
           arguments: |
             --ignore-urls "https://www.github.com,https://fonts.googleapis.com,https://fonts.gstatic.com,_site/_posts/README/index.html"
             --ignore-files "/.+\/_posts\/README.md"
-            --ignore-status-codes "0, 200, 403, 429, 503, 999"
+            --ignore-status-codes "0, 200, 403, 404, 429, 503, 999"

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -51,6 +51,5 @@ jobs:
         with:
           directory: "_site"
           arguments: |
-            --ignore-urls "https://www.github.com,https://fonts.googleapis.com,https://fonts.gstatic.com,_site/_posts/README/index.html"
             --ignore-files "/.+\/_posts\/README.md"
-            --ignore-status-codes "0, 200, 403, 404, 429, 503, 999"
+            --checks "Images,Scripts"


### PR DESCRIPTION
closes #406 
i'm over html proofer failing every new page that we add. this pr ignores links which should allow it to pass on new pages if alt tags and scripts are working. 

see:  [specify checks](https://github.com/gjtorikian/html-proofer?tab=readme-ov-file#configuration) `checks=[images, scripts]`  

if this doesn't work we can just ignore 404 errors but the build will be slower. 