### PR TITLE
Fix Tutorial listing on Learn page

### DIFF
--- a/_pages/learn.md
+++ b/_pages/learn.md
@@ -57,9 +57,7 @@ toc: false
 
 ## Start learning: Beginner-friendly Python packaging tutorials
 
-Beginner-friendly Python packaging tutorials that will take you through
-the full process of creating a Python package, following modern best
-practices.
+Beginner-friendly Python packaging tutorials guide you through creating a Python package, following modern best practices. It's best to follow the tutorials in order, but you can always pick a specific topic if you wish to jump around.
 
 <div class="tutorial__container">
 {% for atutorial in site.tutorials %}

--- a/_tutorials/0-hatch-python-packaging.md
+++ b/_tutorials/0-hatch-python-packaging.md
@@ -1,5 +1,5 @@
 ---
-title: "Add metadata using a pyproject.toml file to your Python package"
+title: "0. Get to know Hatch"
 excerpt: "
   Hatch is an end-to-end Python packaging and workflow tool. In this tutorial, you will install and learn how to configure Hatch for Python packaging."
 learning_objectives:

--- a/_tutorials/1-what-is-package.md
+++ b/_tutorials/1-what-is-package.md
@@ -1,5 +1,5 @@
 ---
-title: "What is a Python package"
+title: "1. What is a Python package"
 excerpt: "
   Learn about what a Python package is and the basic components that make up a Python package."
 learning_objectives:

--- a/_tutorials/2-make-code-installable.md
+++ b/_tutorials/2-make-code-installable.md
@@ -1,5 +1,5 @@
 ---
-title: "Make your Python code installable"
+title: "2. Make your Python code installable"
 excerpt: "
   Learn how to create the most basic version of a Python package which can then be installed into a Python environment."
 learning_objectives:

--- a/_tutorials/3-publish-to-pypi.md
+++ b/_tutorials/3-publish-to-pypi.md
@@ -1,5 +1,5 @@
 ---
-title: "Publish your Python package to PyPI"
+title: "3. Publish your Python package to PyPI"
 excerpt: "
   Learn how to publish your Python package to test.PyPI.org and to PyPI.org."
 learning_objectives:

--- a/_tutorials/4-publish-conda-forge.md
+++ b/_tutorials/4-publish-conda-forge.md
@@ -1,5 +1,5 @@
 ---
-title: "Publish your Python package to conda forge using grayskull"
+title: "4. Publish your Python package to conda forge using grayskull"
 excerpt: "
   Learn how to publish your Python package to the conda-forge channel of conda using the grayskull Python package."
 learning_objectives:

--- a/_tutorials/5-add-readme.md
+++ b/_tutorials/5-add-readme.md
@@ -1,5 +1,5 @@
 ---
-title: "Add a README file to your Python package"
+title: "5. Add a README file to your Python package"
 excerpt: "
   A README file is often the landing page that a user will use to understand your package. Learn about how to create a useful README file for your Python package."
 learning_objectives:

--- a/_tutorials/6-add-license-code-of-conduct.md
+++ b/_tutorials/6-add-license-code-of-conduct.md
@@ -1,5 +1,5 @@
 ---
-title: "Add a LICENSE and Code_of_Conduct file to your Python package"
+title: "6 . Add a LICENSE and CODE_OF_CONDUCT file to your Python package"
 excerpt: "
   License and code of conduct files are important to add to your Python package as they provide instructions for both how users can use your package and also how the community of users should interact with you as a maintainer."
 learning_objectives:

--- a/_tutorials/7-add-metadata-pyproject-toml.md
+++ b/_tutorials/7-add-metadata-pyproject-toml.md
@@ -1,5 +1,5 @@
 ---
-title: "Add metadata using a pyproject.toml file to your Python package"
+title: "7. Add metadata using a pyproject.toml file to your Python package"
 excerpt: "
   To enhance the visibility of your package on PyPI and provide more information about its compatibility with Python versions, project development status, and project maintainers, you should add additional metadata to your pyproject.toml file. This lesson will guide you through the process."
 learning_objectives:


### PR DESCRIPTION
This PR includes a small contribution renaming and fixing tutorials names on the Learn page. 

- Close https://github.com/pyOpenSci/python-package-guide/issues/299
