### PR TITLE
Use main branch of pyosMeta

### DIFF
--- a/.github/workflows/update-contribs-reviews.yml
+++ b/.github/workflows/update-contribs-reviews.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pip install pyosmeta
+          pip install git+https://github.com/pyOpenSci/pyosmeta.git@main
           update-contributors
           update-reviews
           update-review-teams


### PR DESCRIPTION
This would use unreleased features/fixes off https://github.com/pyOpenSci/pyosMeta directly. You may also reject this PR and make a new release to https://pypi.org/project/pyosmeta/ instead in order to fix failing https://github.com/pyOpenSci/pyopensci.github.io/actions/workflows/update-all-review-data.yml that theoretically was patched in https://github.com/pyOpenSci/pyosMeta/pull/166