### PR TITLE
Freshen up tha header a little

### DIFF
--- a/_includes/feature_row_pyos
+++ b/_includes/feature_row_pyos
@@ -8,7 +8,7 @@
   {% for f in feature_row %}
     <div class="cards highlight">
       {% if f.image_path %}
-      <div>
+      <div class="cards__image">
         <img src="{{ f.image_path | relative_url }}"
              alt="{% if f.alt %}{{ f.alt }}{% endif %}">
         {% if f.image_caption %}

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,59 +1,61 @@
 {% capture logo_path %}{{ site.logo }}{% endcapture %}
 
 <div class="masthead">
-  <div class="masthead__inner-wrap">
-    <div class="masthead__menu">
-      <nav id="site-nav" class="nav__topbar" aria-label="Top Bar">
-        <!-- More accessible as a screen reader will group the title and image in the same link -->
-        {% unless logo_path == empty %}
-        <a class="site-logo" href="{{ '/' | relative_url }}">
-          <img src="{{ logo_path | relative_url }}" alt="Welcome to the pyOpenSci website. The pyOpenSci logo is a purple flower opening over the O (for open).">
-        </a>
-        {% endunless %}
+  <nav id="site-nav" class="masthead__menu" aria-label="Top Bar">
+    <!-- More accessible as a screen reader will group the title and image in the same link -->
+    {% unless logo_path == empty %}
+    <a class="site-logo" href="{{ '/' | relative_url }}">
+      <img src="{{ logo_path | relative_url }}" alt="Welcome to the pyOpenSci website. The pyOpenSci logo is a purple flower opening over the O (for open).">
+    </a>
+    {% endunless %}
 
-      <ul class="nav__links">
-        {%- for alink in site.data.navigation.main -%}
-        <!-- If there are sub links drop down nav to display -->
-              {% if alink.sub-nav %}
-             <li class="dropdown">
-                <button class="dropbtn" tabindex="0" aria-expanded="false">{{ alink.title }} <i class="fas fa-caret-down"></i>
-                </button>
-                <ul class="dropdown-content">
-                  {% for subnav in alink.sub-nav %}
-                  <li>
-                    <a href="{{ subnav.url | relative_url }}" class="masthead__menu-item hover-underline">{{ subnav.title }}
-                      {% if subnav.icon %} <i class="{{ subnav.icon }}"></i> {% endif %}
-                    </a>
-                  </li>
-                  {% endfor %}
-                </ul>
-            </li>
-              {% else %}
+    <div class="spacer"></div>
+
+    <ul class="nav__links">
+      {%- for alink in site.data.navigation.main -%}
+      <!-- If there are sub links drop down nav to display -->
+        {% if alink.sub-nav %}
+          <li class="dropdown">
+            <button class="dropbtn" tabindex="0" aria-expanded="false">
+              {{ alink.title }} <i class="fas fa-caret-down"></i>
+            </button>
+            <ul class="dropdown-content">
+              {% for subnav in alink.sub-nav %}
               <li>
-                <a href="{{ alink.url | relative_url }}" class="hover-underline">{{ alink.title }}</a>
+                <a
+                  href="{{ subnav.url | relative_url }}"
+                  class="masthead__menu-item hover-underline"
+                  >{{ subnav.title }}
+                  {% if subnav.icon %}
+                  <i class="{{ subnav.icon }}"></i>
+                  {% endif %}
+                </a>
               </li>
-              {% endif %}
-        {% endfor %}
-        <li>
+              {% endfor %}
+            </ul>
+          </li>
+        {% else %}
+          <li>
+            <a href="{{ alink.url | relative_url }}" class="hover-underline">
+              {{ alink.title }}
+            </a>
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ul>
 
-      </li>
-      </ul>
+    {% if site.search == true %}
+        <button class="search__toggle" type="button">
+        <span class="visually-hidden">{{ site.data.ui-text[site.locale].search_label | default: "Toggle search" }}</span>
+        <i class="fas fa-search"></i>
+      </button>
+    {% endif %}
 
-      {% if site.search == true %}
-          <button class="search__toggle" type="button">
-          <span class="visually-hidden">{{ site.data.ui-text[site.locale].search_label | default: "Toggle search" }}</span>
-          <i class="fas fa-search"></i>
-        </button>
-      {% endif %}
-
-
-      <ul class="hidden-links hidden"></ul>
-        <!-- Burger button  - span class for screen readers-->
-        <button class="hamburger__btn-toggle" type="button" count="1" aria-expanded="false">
-          <span class="visually-hidden">Toggle top navigation menu</span> <!--screen readers-->
-          <div class="burger__icon"></div>
-        </button>
-      </nav>
-      </div>
-    </div>
-  </div>
+    <ul class="hidden-links hidden"></ul>
+    <!-- Burger button  - span class for screen readers-->
+    <button class="hamburger__btn-toggle" type="button" count="1" aria-expanded="false">
+      <span class="visually-hidden">Toggle top navigation menu</span> <!--screen readers-->
+      <div class="burger__icon"></div>
+    </button>
+  </nav>
+</div>

--- a/_sass/minimal-mistakes/_masthead.scss
+++ b/_sass/minimal-mistakes/_masthead.scss
@@ -1,6 +1,11 @@
-/* ==========================================================================
-   MASTHEAD
-   ========================================================================== */
+/*
+==========================================================================
+MASTHEAD
+
+Layout of the top-level items within the masthead.
+For styling of menu contents, see _pyos-dropdown.scss
+==========================================================================
+*/
 
 .masthead {
   position: relative;
@@ -11,36 +16,65 @@
   animation-delay: 0.15s;
   z-index: 20;
 
-  &__inner-wrap {
+
+  &__menu {
     @include clearfix;
-    margin-left: auto;
-    margin-right: auto;
-    padding: 1em;
+    margin: auto;
+    padding: 0 1em;
     max-width: 100%;
-    display: -webkit-box;
-    display: -ms-flexbox;
+    height: 3rem;
     display: flex;
-    -webkit-box-pack: justify;
-    -ms-flex-pack: justify;
     justify-content: space-between;
     font-family: $sans-serif-narrow;
+    position: relative;
+    align-items: stretch;
+    min-height: 2em;
+    background: #fff;
 
-    @include breakpoint($x-large) {
-      max-width: $max-width;
-    }
-
-    nav {
-      z-index: 10;
+    & > * {
+      margin: auto;
     }
 
     a {
       text-decoration: none;
     }
+
+    @include breakpoint($x-large) {
+      max-width: $max-width;
+    }
+
+    .spacer {
+      flex-grow: 1;
+    }
   }
 }
 
-.site-logo img {
-  max-height: 2rem;
+.site-logo {
+  height: 8em;
+  width: 8.5em;
+  top: -2.5em;
+  left: -2em;
+  position:relative;
+  background-color: $background-color;
+  border: 1px solid $border-color;
+  box-shadow: 3px 3px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+
+  &::after {
+    padding-bottom: 100%;
+  }
+
+  img {
+    object-fit: contain;
+    height: 4em;
+    width: 75%;
+    margin: 0 auto 1.25em auto;
+    display: block;
+    box-shadow: none;
+    align-self: end;
+  }
 }
 
 .site-title {
@@ -50,44 +84,11 @@
   -ms-flex-item-align: center;
   align-self: center;
   font-weight: bold;
-  // z-index: 20;
 }
 
 .site-subtitle {
   display: block;
-  font-size: $type-size-8;
-}
-
-.masthead__menu {
-  float: left;
-  margin-left: 0;
-  margin-right: 0;
-  width: 100%;
-  clear: both;
-
-  .site-nav {
-    margin-left: 0;
-
-    @include breakpoint($small) {
-      float: right;
-    }
-  }
-
-  ul {
-    margin: 0;
-    padding: 0;
-    clear: both;
-    list-style-type: none;
-  }
-}
-
-.masthead__menu-item {
-  display: block;
-  list-style-type: none;
-  white-space: nowrap;
-
-  &--lg {
-    padding-right: 2em;
-    font-weight: 700;
-  }
+  font-weight: 400;
+  font-size: .8em;
+  color: $nav-font-color;
 }

--- a/_sass/minimal-mistakes/_pyos-dropdown.scss
+++ b/_sass/minimal-mistakes/_pyos-dropdown.scss
@@ -1,42 +1,21 @@
 
 /* ==========================================================================
    pyos custom drop down menus
+
+   Styles for the *contents* of the menus and the
+   menu buttons. For layout within the page,
+   see _masthead.scss
    ========================================================================== */
-
-/* replaces mm greedy_nav */
-.nav__topbar {
-  position: relative;
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-height: 2em;
-  background: #fff;
-}
-
-/* Center logo in div - TODO: adjust fonts (will do this at end) */
-.site-subtitle {
-  font-weight: 400;
-  font-size: .8em!important;
-  color: $nav-font-color;
-}
-
-.site-logo img {
-  margin-left: auto;
-  margin-right: auto;
-  display: block;
-  max-height: 3rem!important;
-  box-shadow: none!important;
-}
-
 
 .nav__links {
   overflow: hidden;
+  margin: 0 auto;
+  padding: 0;
   display: flex;
-  align-items: center;
-  margin-left: auto!important;
+  align-items: stretch;
+  gap: 1em;
+  clear: both;
+  list-style-type: none;
 
   a {
     float: left;
@@ -55,6 +34,60 @@
   .icon {
     display: none;
   }
+
+  @media (max-width: $medium-wide){
+    gap: 0.5em;
+  }
+
+  /* Upon click the menu should turn into a vertical stacked menu with a soft
+  drop shadow */
+  &.vertical {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 0 1em;
+    margin-top: 2em;
+    top: 90%;
+    left: 5%;
+    right: 5%;
+    gap: 0;
+    font-size: 1.2em;
+    background-color: #fff;
+    z-index: 1;
+    border: 1px solid #f2f3f3;
+    border-radius: 4px;
+    -webkit-box-shadow: 0 2px 4px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
+    box-shadow: 0 2px 4px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
+
+    a {
+      float: none;
+      display: block;
+      text-align: left;
+    }
+
+    li {
+      width: 100%;
+    }
+
+    .dropdown {
+      float: none;
+
+      .dropbtn {
+        width: 100%;
+        text-align: left;
+        display: block;
+        padding: 1em 0;
+      }
+
+      .dropdown-content {
+        width: 100%;
+        min-width: 100%;
+        position: relative;
+        box-shadow: unset;
+      }
+    }
+  }
 }
 
 /* down arrow works better with ascii vs font awesome */
@@ -67,67 +100,61 @@
   font-size: 1em!important;
 }
 
-/* Make sure drop down horizontal doesn't push content down
-(put push it down in vertical mode */
-.nav__links .dropdown .dropdown-content {
-  position: absolute;
-  max-width: 25%;
-}
+/* Dropdown container for nav links */
+.dropdown {
+  float: left;
+  overflow: hidden;
 
-/* Upon click the menu should turn into a vertical stacked menu with a soft
-drop shadow
-*/
-.nav__links.vertical {
-  position: absolute;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  margin-top: 2em;
-  top: 90%;
-  left: 0%;
-  width: 100%;
-  font-size: 1.2em;
-  background-color: #fff;
-  z-index: 1;
-  border: 1px solid #f2f3f3;
-  border-radius: 4px;
-  -webkit-box-shadow: 0 2px 4px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
-  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
-
-  li {
-    width: 100%;
-  }
-
-  .dropdown-content {
-    min-width: 100%;
-  }
   .dropbtn {
+    border: none;
+    outline: none;
+    color: $nav-font-color;
+    height: 100%;
+    background-color: inherit;
+    font-family: inherit;
+    margin: 0;
+    line-height: 1em;
+  }
+
+  /* Style the dropdown content (hidden by default) */
+  .dropdown-content {
+    display: none;
+    background-color: #fff;
+    min-width: 160px;
+    max-width: 25%;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1;
     width: 100%;
-    text-align: left;
-  }
+    transition: all 0.25s ease-in;
+    transform: translateY(-10px);
+    position: absolute;
 
-  a {
-    float: none;
-    display: block;
-    text-align: left;
-  }
-  .dropdown {
-    float: none;
-  }
+    &.open {
+      display: block;
+    }
 
-  .dropdown-content {position: relative;}
+    li {
+      list-style-type: none;
+    }
 
-  .dropdown .dropbtn {
-    display: block;
-    width: 100%;
-    text-align: left;
-  }
+    a {
+      float: none;
+      // color: black;
+      padding: 12px 16px;
+      text-decoration: none;
+      display: block;
+      text-align: left;
+      white-space: nowrap;
 
-  .dropdown .dropdown-content {
-    position: relative!important;
-    width: 100%;
+      &:hover {
+        background-color: #fff;
+        color: $nav-hover-color;
+      }
+    }
   }
 }
+
+
 /*  End nav links bar styles */
 
 /* Begin burger stylin */
@@ -168,7 +195,7 @@ drop shadow
 }
 
 /* Begin burger styling: actual hamburger element (the horiz lines)*/
- .burger__icon {
+.burger__icon {
   position: relative;
   width: 1.5rem;
   height: .25rem;
@@ -178,12 +205,6 @@ drop shadow
   transition: 0.3s;
 }
 
-/* Position the burger in it's x closed state - min mistakes didn't have to do this */
-.close .burger__icon {
-  position: absolute;
-  top: auto;
-  right: .1em;
-}
 
 /* Hide the middle bar when in "closed" style state so it's an x */
 .close .burger__icon {
@@ -236,52 +257,7 @@ drop shadow
 }
 /*  end burger */
 
-/* Dropdown container for nav links */
-.dropdown {
-  float: left;
-  overflow: hidden;
 
-  .dropbtn {
-    border: none;
-    outline: none;
-    color: $nav-font-color;
-    padding: 14px 16px;
-    background-color: inherit;
-    font-family: inherit;
-    margin: 0;
-  }
-}
-
-/* Style the dropdown content (hidden by default) */
-.dropdown-content {
-  display: none;
-  background-color: #fff;
-  min-width: 160px;
-  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-  z-index: 1;
-  width: 100%;
-  transition: all 0.25s ease-in;
-  transform: translateY(-10px);
-}
-
-/* Style the links inside the dropdown */
-.dropdown-content a {
-  float: none;
-  // color: black;
-  padding: 12px 16px;
-  text-decoration: none;
-  display: block;
-  text-align: left;
-}
-
-.dropdown-content a:hover {
-  background-color: #fff;
-  color: $nav-hover-color;
-}
-
-.dropdown .dropdown-content.open {
-  display: block;
-}
 /* This style may be removed ultimately - it is the fancy underline */
 
 .hover-underline {
@@ -322,7 +298,7 @@ drop shadow
   color: white;
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: $medium) {
 
   /* Hide horizontal drop down links at 48em / 768px */
   .nav__links { display: none;}
@@ -337,21 +313,10 @@ drop shadow
 
   .hamburger__btn-toggle {
     display: block;
-    position: absolute;
-    top: 5%;
-    right: 5%;
     width: 2.0rem;
   }
 
   .burger__icon, burger__icon::before, burger__icon::after {
     display: block; }
 
-  /* Positioned by burger
-  TODO: might be better within the drop down??*/
-  .search__toggle {
-    position: absolute;
-    right: -6%;
-    font-size: 1.4em;
-    top: 3%;
-  }
 }

--- a/_sass/minimal-mistakes/_pyos-dropdown.scss
+++ b/_sass/minimal-mistakes/_pyos-dropdown.scss
@@ -47,7 +47,7 @@
     flex-direction: column;
     align-items: flex-start;
     padding: 0 1em;
-    margin-top: 2em;
+    margin-top: 3em;
     top: 90%;
     left: 5%;
     right: 5%;

--- a/_sass/minimal-mistakes/_pyos-grid.scss
+++ b/_sass/minimal-mistakes/_pyos-grid.scss
@@ -37,7 +37,7 @@ $colors: (
 .grid {
     display: grid;
     // minmax can be used to modify width
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(calc($small/2), 1fr));
     grid-gap: 10px;
 
     h4.grid_title {
@@ -133,7 +133,7 @@ $colors: (
 .cards {
     top: 0px;
     position: relative;
-    max-width: 362px;
+    // max-width: 362px;
     background-color: #fcfbf5;;
     border-radius: 4px;
     text-decoration: none;
@@ -141,6 +141,12 @@ $colors: (
     overflow: hidden;
     border: 1px solid #f2f8f9;
     font-size: .8em;
+
+    &__image {
+      max-height: calc($small/3);
+      overflow: hidden;
+      border-radius: 10px;
+    }
 
     &.highlight div {
       padding:0;

--- a/_sass/minimal-mistakes/_pyos-main.scss
+++ b/_sass/minimal-mistakes/_pyos-main.scss
@@ -213,10 +213,6 @@ h2.clearall {
     font-size: .9em!important;
   }
 
-  .search__toggle {
-    margin-right: -4rem!important;
-  }
-
   .back-to-top {
     font-size: 1.2em!important;
   }


### PR DESCRIPTION
Fix: https://github.com/pyOpenSci/pyopensci.github.io/issues/456

needed something to procrastinate on for an hour or two this afternoon bc couldn't think about data modeling anymore.

OK so here is a tour of widths on the current homepage:

https://github.com/user-attachments/assets/8b9608c4-90d0-4d6a-ae67-0b7bd03770c2

and here is this PR

https://github.com/user-attachments/assets/d5d362d9-7815-437a-9c90-b897de2025cb

so not THAT different but here are the highlights.

- save the search button on mobile! the issue there was that it and the burger menu button were absolutely positioned, and in particular the search button had a media query that pushed it off the page when the screen was small. So i turned the header bar into a flexbox instead and added a spacer element to push everything to the right with and without the link buttons being present. I also unnested the multiple levels of wrapping elements that were making it a bit hard to work with the header bar bc padding was specified in multiple places, etc. Then the rest of the changes in `masthead.html` are me reformatting the template html a bit with prettier.
- clean up the stylesheets! there were a decent number of redundant styles for the same classes and elements split across two files, masthead and pyos_dropdown. I could tell there was a bit of frustration from that from all the `!important` tags there, where the styles were conflicting with one another. I cleaned it up so all the "top-level" layout stuff of where stuff is on the header bar is in `masthead` and then everything for the dropdown menus was in `pyos_dropdown`, and i grouped together definitions for nested classes that were also defined in multiple places so that way we aren't mixing levels and confusing ourselves :). This was for maintenance's sake but also since we are having some [perf problems](https://github.com/pyOpenSci/pyopensci.github.io/pull/373), specifically in the css rendering part, i figure we might as well start to trim down unused/conflicting styles so the first render can start getting a little faster.
- similarly, i started setting some explicit heights to the topmost things so we can avoid unnecessary reflows/recomputes, but that wasn't the main goal, more prep for more focused perf work in the future.
- I noticed that the card items were a little hard to read at narrow widths: 
  <img width="447" alt="Screenshot 2024-08-01 at 7 39 01 PM" src="https://github.com/user-attachments/assets/01d33089-0ebd-451d-8e2d-38a4fe2f0f1d">
  so i made this breakpoint a bit wider and added some stuff to keep the images from getting humongous when that happened.
- I also noticed that the menus had this sort of odd shadow border to them that looked unintentional, so i removed it, but lmk if that was intentional and i can add it back:

| pre | post |
| --- | --- |
| <img width="434" alt="Screenshot 2024-08-01 at 7 41 01 PM" src="https://github.com/user-attachments/assets/441b85a9-1092-4702-9433-a1b50c5caa56"> | <img width="440" alt="Screenshot 2024-08-01 at 7 41 55 PM" src="https://github.com/user-attachments/assets/e10af438-b9e0-45ab-82a9-96587a4845e1"> |

- and then finally i made the bar a little narrower because imo it's sort of large at desktop sizes, and then to keep the logo prominent i put it in a little bubble with a retro border :)

| pre | post |
| --- | --- |
| <img width="1330" alt="Screenshot 2024-08-01 at 7 43 56 PM" src="https://github.com/user-attachments/assets/bb98889b-431f-4261-bc28-2cfb86ca118d"> | <img width="1332" alt="Screenshot 2024-08-01 at 7 44 57 PM" src="https://github.com/user-attachments/assets/7668463f-f5a4-4578-aecf-3add981f5e91"> |

anyway i know this is *not* a modular PR, so if we don't like any of these changes it's no problem to take them out. just once i got started i sorta couldn't stop touchin stuff and here we are
