### PR TITLE
Add github image ID for new editors

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -7444,7 +7444,7 @@
   email: melissawm@gmail.com
 - name: Russ Biggs
   github_username: russbiggs
-  github_image_id:
+  github_image_id: 8487728
   title:
   sort:
   bio:
@@ -7469,7 +7469,7 @@
   email:
 - name: Kelly L. Rowland
   github_username: kellyrowland
-  github_image_id:
+  github_image_id: 5440574
   title:
   sort:
   bio:
@@ -7494,7 +7494,7 @@
   email:
 - name: Silvana Ovaitt
   github_username: shirubana
-  github_image_id:
+  github_image_id: 22824806
   title:
   sort:
   bio:


### PR DESCRIPTION
The three new editors did not have their github avatar id.
I have added them so they are displayed on the website.