### PR TITLE
Remove TBD as contributor

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -7603,35 +7603,6 @@
   packages_reviewed:
   location:
   email: jon.kiparsky@gmail.com
-- name: TBD
-  github_username: TBD
-  github_image_id: 7951
-  title:
-  sort:
-  bio: New apps/language tester, SketchUp Podium 1.x developer, Internet of Things
-      tinker
-  organization:
-  date_added: '2024-10-15'
-  deia_advisory: false
-  editorial_board:
-  emeritus_editor: false
-  advisory: false
-  emeritus_advisory: false
-  twitter:
-  mastodon:
-  orcidid:
-  partners:
-  website:
-  board: false
-  contributor_type:
-    - peer-review
-    - reviewer
-  packages_editor:
-  packages_submitted:
-  packages_reviewed:
-    - stingray
-  location: Timisoara, Romania
-  email: tbd_fr@yahoo.fr
 - name: Matteo Bachetti
   github_username: matteobachetti
   github_image_id: 7190189


### PR DESCRIPTION
Parsing a submission with non updated information a TBD contributor has been added by mistake.
This commit remove them.