### PR TITLE
Fix: this is a workflow test

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -6928,7 +6928,7 @@
   packages_reviewed:
   location:
   email: kyle.a.oman@durham.ac.uk
-- name:
+- name: Phil Dong
   github_username: phildong
   github_image_id: 35715936
   title:


### PR DESCRIPTION
Here, I'm testing to see if we can populate a person's name in the contributor file. Does it register in our workflow properly?  This is a change that @pllim made the other day (but to the packages file which is handled slightly differently.