### PR TITLE
Fix: astropy landing shoould use labels vs partners

### DIFF
--- a/communities/astropy.md
+++ b/communities/astropy.md
@@ -14,9 +14,10 @@ classes: wide
 community: astropy
 ---
 
+
 {%
     assign pkgs = site.data.packages
-    | where_exp: "item", "item.partners contains page.community" | sort_natural: 'date_accepted' | reverse
+    | where_exp: "item", "item.labels contains page.community" | sort_natural: 'date_accepted' | reverse
 %}
 
 {% assign total_packages = pkgs | size %}


### PR DESCRIPTION
closes #575 

This is just a tiny fix to make sure we're grabbing affiliated data from an editor curated field