### PR TITLE
[Proposal] Autofix PRs with pre-commit CI

### DIFF
--- a/.github/workflows/update-all-review-data.yml
+++ b/.github/workflows/update-all-review-data.yml
@@ -25,10 +25,6 @@ jobs:
           update-contributors --update update_all
           update-reviews
           update-review-teams
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: --files _data/packages.yml _data/contributors.yml
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/.github/workflows/update-contribs-reviews.yml
+++ b/.github/workflows/update-contribs-reviews.yml
@@ -30,9 +30,6 @@ jobs:
           update-reviews
           update-review-teams
 
-      - name: run precommit hooks
-        uses: pre-commit/action@v3.0.1
-        continue-on-error: true
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@
 # - Register git hooks: pre-commit install --install-hooks
 
 ci:
-  autofix_prs: false
+  autofix_prs: true
   #skip: [flake8, end-of-file-fixer]
   autofix_commit_msg: |
     '[pre-commit.ci 🤖] Apply code format tools to PR'


### PR DESCRIPTION
This opts into automatically fixing PRs with pre-commit CI and removes `pre-commit/action` from the GitHub Actions workflows

- The  `pre-commit/action` GitHub Action is in maintenance only mode and they recommend swithing to pre-commit CI
- We previously used `pre-commit/action` to automatically reformat the YAML data files generated during the automated data update jobs.
- This PR will instead have those jobs automatically update the data, then pre-commit will automatically fix the formatting as a second commit.

This will remove the confusing error annotation we're seeing on the data update CI jobs since the pre-commit check technically fails since it reformats the YAML data files after they are generated