### PR TITLE
Add inline link to Python Packaging Guide from packaging resources page (#441)

### DIFF
--- a/_pages/packaging-resources.md
+++ b/_pages/packaging-resources.md
@@ -47,6 +47,9 @@ community-created:
      excerpt: "
      Our packaging guide is a living document that will help you navigate the Python packaging ecosystem and learn about modern Python packaging best practices.
 
+     Explore our Python packaging guide: [Python Packaging Guide](/python-package-guide/).
+
+
     * Created & curated by the community
 
     * Reviewed by beginner to expert level Pythonistas


### PR DESCRIPTION
This PR addresses [#441](https://github.com/pyOpenSci/pyopensci.github.io/issues/441?utm_source=chatgpt.com)
.

What I changed:

Added a direct inline link to the Python Packaging Guide on the [Python Packaging Resources for Scientists](https://www.pyopensci.org/python-packaging-science.html?utm_source=chatgpt.com)
 page.

The link is placed directly below the introductory text about the guide to improve discoverability.

Why this change is needed:

Previously, readers couldn’t easily navigate to the packaging guide from the body text — they had to rely on the sidebar navigation.

Adding this link makes the guide easier to find, improves user experience, and resolves the navigation gap reported in issue #441.

How I tested it:

Built the site locally with bundle exec jekyll serve.

Verified that the new link appears under the “Community-created Python Packaging Guide” section.

Confirmed that the link correctly navigates to /python-package-guide/.

Closes: #441