### PR TITLE
Add ChemInformant package and  contributor

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -1,3 +1,38 @@
+- name: Zhiang He
+  github_username: HzaCode
+  github_image_id: 0
+  title:
+    - Package Maintainer
+    - Submitting Author
+  sort: 0
+  bio: Developer of ChemInformant, a robust data acquisition engine for the
+      PubChem database. A clinician passionate about scientific
+      software development.
+  organization: Independent
+  date_added: '2025-09-30'
+  deia_advisory: false
+  editorial_board: false
+  emeritus_editor: false
+  advisory: false
+  emeritus_advisory: false
+  twitter:
+  mastodon:
+  orcidid:
+  partners:
+  website: https://hezhiang.com
+  board: false
+  contributor_type:
+    - code-contrib
+    - maintainer
+    - package-maintainer
+    - submitting-author
+  packages_eic:
+  packages_editor:
+  packages_submitted:
+    - cheminformant
+  packages_reviewed:
+  location: China
+  email: ang@hezhiang.com
 - name: Leah Wasser
   github_username: lwasser
   github_image_id: 7649194

--- a/_data/packages.yml
+++ b/_data/packages.yml
@@ -1,3 +1,63 @@
+- package_name: ChemInformant
+  package_description: A robust, high-throughput Python client for retrieving
+      chemical information from the PubChem API; it returns analysis-ready
+      Pandas/SQL outputs, handles caching, rate-limiting and retries, and
+      includes convenient CLI tools.
+  submitting_author:
+      name: Zhiang He
+      github_username: HzaCode
+  all_current_maintainers:
+    - name: Zhiang He
+      github_username: HzaCode
+  repository_link: https://github.com/HzaCode/ChemInformant
+  version_submitted: 2.4.3
+  categories:
+    - data-retrieval
+    - data-extraction
+    - data-processing-munging
+    - data-deposition
+    - data-validation-testing
+    - data-visualization
+    - workflow-automation
+    - citation-management-bibliometrics
+    - scientific-software-wrapper
+    - database-interoperability
+  editor:
+      name: Eliot Robson
+      github_username: eliotwrobson
+  eic:
+      name: Eliot Robson
+      github_username: eliotwrobson
+  reviewers:
+    - name: Eliot Robson
+      github_username: eliotwrobson
+    - name: Eliot Robson
+      github_username: eliotwrobson
+  archive: https://zenodo.org/doi/10.5281/zenodo.17233178
+  version_accepted: 2.4.3
+  date_accepted: '2025-09-30'
+  created_at: 2025-07-31 00:00:00+00:00
+  updated_at: 2025-09-30 00:00:00+00:00
+  closed_at: 2025-09-30 00:00:00+00:00
+  issue_link: https://github.com/pyOpenSci/software-submission/issues/254
+  joss: https://doi.org/10.21105/joss.08341
+  partners:
+  gh_meta:
+      name: ChemInformant
+      description: A robust, high-throughput Python client for retrieving
+          chemical information from the PubChem API
+      created_at: '2025-06-01'
+      stargazers_count: 4
+      watchers_count: 2
+      open_issues_count: 0
+      forks_count: 1
+      documentation: https://hezhiang.com/cheminformant_real.html
+      contrib_count: 2
+      last_commit: '2025-09-30'
+  labels:
+    - 6/pyOS-approved
+    - 9/joss-approved
+  active: true
 - package_name: PIVA
   package_description: Visualization and analysis toolkit for experimental
       data from Angle-Resolved Photoemission Spectroscopy (ARPES)


### PR DESCRIPTION
This PR adds the ChemInformant package to the pyOpenSci website and includes HzaCode as a contributor.