### PR TITLE
Fix Jekyll framework link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ about contributing to our website, our **Python Packaging Guide** and our
 
 ## Installation and Development
 
-Have you decided to contribute? We use the [Jekyll framework](https://jekyllrb.org)
+Have you decided to contribute? We use the [Jekyll framework](https://jekyllrb.com)
 for creating this site. To set up a **development environment** and **run the site locally**, follow these steps:
 
 1. Install ruby and bundler on your machine. See [the Jekyll docs](https://jekyllrb.com/docs/installation/) for instructions.


### PR DESCRIPTION
Original link had the `.org` extension instead of the `.com` extension. The `.org` extension points to a site unrelated to the Jekyll framework.