### PR TITLE
ignore root-relative links in lychee link check

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -33,9 +33,10 @@ jobs:
         uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 #v2.7.0
         with:
           args: >
-          --verbose --no-progress
-          --exclude '^/.*'
-          _site
+            --verbose 
+            --no-progress
+            --exclude '^/.*'
+            _site
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -32,7 +32,10 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 #v2.7.0
         with:
-          args: --verbose --no-progress _site/*.html
+          args: >
+          --verbose --no-progress
+          --exclude '^/.*'
+          _site
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -33,7 +33,7 @@ jobs:
         uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 #v2.7.0
         with:
           args: >
-            --verbose 
+            --verbose
             --no-progress
             --exclude '^/.*'
             _site


### PR DESCRIPTION
Exclude root-relative paths (/…) from the lychee link checker to prevent InvalidPathToUri errors when scanning the built _site HTML. This keeps external link validation intact while avoiding false CI failures on internal site links.