### PR TITLE
docs: remove references and links to the obsolete PyOS Discourse

### DIFF
--- a/_pages/get-in-touch.md
+++ b/_pages/get-in-touch.md
@@ -42,7 +42,7 @@ help-us:
   - image_path:
     title: "Interested in Being an Editor?"
     alt:
-    excerpt: "We also often recruit new editors to support our peer review process. Keep an eye out on our discourse forum for calls for new editors. In the meantime if you are interested in learning more about the editor role, check out our peer review guidebook. "
+    excerpt: "We also often recruit new editors to support our peer review process. Keep an eye out on our [GitHub Discussions](https://github.com/orgs/pyOpenSci/discussions) for calls for new editors. In the meantime if you are interested in learning more about the editor role, check out our peer review guidebook. "
     url: https://www.pyopensci.org/software-peer-review/how-to/editors-guide.html
     btn_label: "> Click here to learn more about the editor role."
     btn_class: btn--inverse

--- a/_pages/how-to-submit-package.md
+++ b/_pages/how-to-submit-package.md
@@ -91,7 +91,7 @@ If you are unsure if your package is in scope, [**🔗 submit a pre-submission i
 It's also a good idea to check that your package meets [**pyOpenSci’s minimum Python package requirements**](https://www.pyopensci.org/software-peer-review/how-to/editor-in-chief-guide.html#editor-checklist-template). So check that your package meets those criteria before you submit.
 The Editor in Chief will check your package against these criteria before the review begins.
 
-If you have any questions or need help getting your package up to pyOpenSci standards, we are here to help. Submit a help-request issue in our software-submission repo or ask a question in our Discourse.
+If you have any questions or need help getting your package up to pyOpenSci standards, we are here to help. Submit a help-request issue in our software-submission repo or ask a question in our [GitHub Discussions](https://github.com/orgs/pyOpenSci/discussions).
 
 <div class="notice" markdown="1">
 Our packaging guide covers the core criteria which include:


### PR DESCRIPTION
Remove references and links to the obsolete PyOS Discourse.