### PR TITLE
enh: Add date_accepted and citation metadata to package cards (#214)

### DIFF
--- a/_includes/package-grid.html
+++ b/_includes/package-grid.html
@@ -42,6 +42,13 @@
       {{ apackage.package_description | markdownify }}
     </div>
 
+    {% if apackage.date_accepted != "missing" %}
+      <div class="package-card__meta" style="margin-top: -0.25em;">
+        <i class="fas fa-calendar-check" aria-hidden="true"></i>
+        <span>Date Accepted: {{ apackage.date_accepted }}</span>
+      </div>
+    {% endif %}
+
     {% unless is_feature %}
     <ul class="package-card__links">
       <li><a href="{{ apackage.repository_link }}" rel="permalink"><i class="fab fa-github" aria-hidden="true"></i> View Code</a></li>
@@ -49,8 +56,14 @@
         <li><a href="{{ apackage.gh_meta.documentation }}" rel="permalink"><i class="fas fa-book-open" aria-hidden="true"></i> View Docs</a></li>
       {% endif %}
       <li><a href="{{ apackage.issue_link }}"><i class="fa-solid fa-user-pen" aria-hidden="true"></i> View Review</a></li>
-      {% if apackage.joss %}
-        <li><a href="{{ apackage.archive }}" rel="permalink"><i class="fas fa-bookmark fa-fw" aria-hidden="true"></i> JOSS Approved</a></li>
+      {% if apackage.joss and apackage.joss contains "joss.theoj.org" %}
+        <li><a href="{{ apackage.joss | replace: 'joss.theoj.org/papers/', 'doi.org/' }}"><i class="fa-solid fa-bookmark" aria-hidden="true"></i> <img src="{{ apackage.joss }}/status.svg" alt="JOSS DIO" /></a></li>
+      {% elsif apackage.joss and package.joss contains "zenodo.org/doi/" %} <!-- case when joss field contains a zenodo link -->
+        <li><a href="{{ apackage.joss | replace: 'zenodo.org/doi/', 'doi.org/' }}"><i class="fa-solid fa-bookmark" aria-hidden="true"></i> <img src="{{ apackage.joss | replace: '.org/', '.org/badge/' }}.svg" alt="DIO" /></a></li>
+      {% elsif apackage.archive and apackage.archive contains "zenodo.org/doi/" %}
+        <li><a href="{{ apackage.archive | replace: 'zenodo.org/doi/', 'doi.org/' }}"><i class="fa-solid fa-bookmark" aria-hidden="true"></i> <img src="{{ apackage.archive | replace: '.org/', '.org/badge/' }}.svg" alt="DIO" /></a></li>
+      {% elsif apackage.archive and apackage.archive != null %}
+        <li><a href="{{ apackage.archive }}"><i class="fa-solid fa-bookmark" aria-hidden="true"></i> View Citation</a></li>
       {% endif %}
       {% if apackage.partners contains "astropy" %}
         <li><a href="/communities/astropy.html"><i class="fa-solid fa-check-double" aria-hidden="true"></i> <img src="https://img.shields.io/badge/Affiliated-Astropy-orange.svg?style=flat" alt="Astropy" /></a></li>


### PR DESCRIPTION
Did this for the PyCon US 26 sprint! Closes #214

To show the citation, I used the archive link in package.yaml and converted it into a badge image link (and doi link). If a JOSS citation exists, that takes priority. I decided to remove the "JOSS Approved" link since this new JOSS citation more-or-less serves the same purpose. This can be brought back if that is preferred.

Preview of what these changes look like:

<img width="407" height="561" alt="Screenshot 2026-05-18 at 2 58 23 PM" src="https://github.com/user-attachments/assets/9662187f-3933-4565-ba4d-bd10353bc437" />
<img width="407" height="561" alt="Screenshot 2026-05-18 at 2 58 37 PM" src="https://github.com/user-attachments/assets/cd95b479-cac3-4e68-89c2-c736b21fac0e" />