### PR TITLE
Fix posts URL failures in link checker

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -56,4 +56,5 @@ jobs:
           directory: "_site"
           arguments: |
             --ignore-files "/.+\/_posts\/README.md"
+            --ignore-urls "/^https?:\/\/(www\.)?pyopensci\.org\//"
             --checks "Images,Scripts"

--- a/_config.yml
+++ b/_config.yml
@@ -165,7 +165,6 @@ footer:
 include:
   - .htaccess
   - _pages
-  - _posts
 exclude:
   - "*.sublime-project"
   - "*.sublime-workspace"

--- a/lychee.toml
+++ b/lychee.toml
@@ -60,4 +60,7 @@ include_verbatim = false
 # Regex excludes. Plain-domain skips belong in .lycheeignore.
 exclude = [
     'zenodo\.org',
+    # Self-references to the deployed site lag the build, producing false
+    # 404s for new pages. Internal links are validated via relative paths.
+    '^https?://(www\.)?pyopensci\.org/',
 ]


### PR DESCRIPTION
CI's link checker fails on every new blog post. HTMLProofer and lychee fetch the absolute self-URL emitted by `_layouts/single.html` (`https://www.pyopensci.org/blog/<post>.html`) before the page is deployed, so they 404. Excluding the self-domain in both tools clears the false failures.

Separately, `_config.yml` listed `_posts` under `include:`. Jekyll already collects `_posts` as a built-in, so every post was processed twice and the build emitted "destination shared by multiple files" warnings. Removing the duplicate entry clears them.

Link checkers will no longer flag internal links written as absolute `https://www.pyopensci.org/...` URLs. Internal links should use relative paths anyway and are validated against the local `_site` build.
