### PR TITLE
fix: admonition paragraphs work now

### DIFF
--- a/themes/clean-hugo/assets/css/_admonition.scss
+++ b/themes/clean-hugo/assets/css/_admonition.scss
@@ -46,6 +46,10 @@
     max-width: none;
     line-height: 1.6;
 
+    p {
+      font-size: clamp(0.99rem, 2vw, 1rem);
+    }
+
     .btn {
       margin-top: 0.75rem;
     }

--- a/themes/clean-hugo/layouts/shortcodes/admonition.html
+++ b/themes/clean-hugo/layouts/shortcodes/admonition.html
@@ -23,18 +23,7 @@
       </div>
     {{- end -}}
     <div class="admonition__body">
-      {{- $inner := .Inner -}}
-      {{- $inner = replace $inner "<a href" "\n\n<a href" -}}
-      {{- $inner = replace $inner "<figure" "\n\n<figure" -}}
-      {{- range split $inner "\n\n" -}}
-        {{- $block := trim . " \n\r\t" -}}
-        {{- if not $block -}}
-        {{- else if or (hasPrefix $block "<") (hasPrefix $block "<!--") -}}
-          {{ $block | safeHTML }}
-        {{- else -}}
-          {{ $block | markdownify | safeHTML }}
-        {{- end -}}
-      {{- end -}}
+      {{ .Inner | markdownify }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
There was a bug where admonitions weren't rendering proposal if they had paragraphs. this fixes that

<img width="849" height="605" alt="Screenshot 2026-06-18 at 1 27 12 PM" src="https://github.com/user-attachments/assets/b5f91c32-24ab-4574-9a40-33f3cad4d9b9" />

<img width="789" height="398" alt="Screenshot 2026-06-18 at 1 27 27 PM" src="https://github.com/user-attachments/assets/1ad34dd4-9b58-4500-84e7-c1f9d9ada0ea" />
