### PR TITLE
enh: flesh out peer review roles

### DIFF
--- a/content/about-peer-review.md
+++ b/content/about-peer-review.md
@@ -43,7 +43,7 @@ is accepted and in scope for JOSS, it will be fast-tracked through JOSS'
 review process.
 {{< /feature-row >}}
 
-{{< section-heading title="Get involved with software peer review" >}}
+{{< section-heading title="Get involved with software peer review" />}}
 
 {{< two-card-row >}}
 {{< card title="Become a pyOpenSci reviewer" icon="fa-solid fa-user-pen" >}}

--- a/content/blog/2026-05-01-clean-hugo-blog-theme-features.md
+++ b/content/blog/2026-05-01-clean-hugo-blog-theme-features.md
@@ -637,7 +637,7 @@ shortcode form (percent signs).
 **Rendered:**
 
 {{< section_band color="light-purple" divider="bottom" >}}
-{{< section-heading title="Inside a swoosh section" subtitle="Purple background • optional top or bottom curve" >}}
+{{< section-heading title="Inside a swoosh section" subtitle="Purple background • optional top or bottom curve" />}}
 {{< /section_band >}}
 
 
@@ -831,7 +831,7 @@ hierarchy.
 {{< section-heading
   title="Section heading example"
   subtitle="Optional subtitle text • Can use • separators"
->}}
+/>}}
 
 
 ## Metrics bar

--- a/content/volunteer.md
+++ b/content/volunteer.md
@@ -13,29 +13,37 @@ cards_layout: five
 cards_padding: compact
 cards:
   - modifier: "card--white"
-    title: "Become a Reviewer"
+    title: "Become a reviewer"
     label: "Async"
     label_style: "accent"
     tags:
       - "Technical review"
-      - "~5–10 hrs / review"
+      - "~3–10 hrs / review"
     excerpt: >-
       As a reviewer, you'll either volunteer when a package request is posted in our Slack
       or be invited based on your domain expertise or packaging experience. Newer reviewers
       often focus on domain application and package usability, while experienced reviewers
       may dig deeper into packaging best practices. Most reviewers complete one or two
-      reviews per year, with each review taking roughly 3–10 hours depending on the package's complexity. Reviewers also receive mentorship from more experienced reviewers to help them through the process.
+      reviews per year, with each review taking roughly 3–10 hours depending on
+      the package's complexity. Reviewers also receive mentorship from more
+      experienced reviewers to help them through the process.
     url: "https://forms.gle/GHfxvmS47nQFDcBM6"
     cta: "Apply to be a reviewer"
   - modifier: "card--white"
-    title: "Apply to be an Editor"
+    title: "Become an editor"
     label: "Async"
     label_style: "accent"
     tags:
       - "Editorial oversight"
       - "~3–5 hrs / month"
     excerpt: >-
-      As an editor, you'll lead and guide the review process end-to-end — finding and onboarding reviewers who match the package's domain, keeping the review on track, and ensuring reviewers and maintainers meet deadlines. Editors typically lead 2–4 reviews per year, with each active review requiring roughly 1–3 hours per week and quieter periods in between. It's a great opportunity to grow project management skills while supporting open science.
+      As an editor, you'll lead and guide the review process end-to-end —
+      finding and onboarding reviewers who match the package's domain, keeping
+      the review on track, and ensuring reviewers and maintainers meet
+      deadlines. Editors typically lead 2–4 reviews per year, with each active
+      review requiring roughly 1–3 hours per week and quieter periods in
+      between. It's a great opportunity to grow project management skills while
+      supporting open science.
     url: "https://forms.gle/XeWcutoLzr54oDv27"
     cta: "Apply to be an editor"
   - modifier: "card--white"
@@ -43,38 +51,60 @@ cards:
     label: "Async"
     label_style: "accent"
     tags:
-      - "Intake & routing"
-      - "~2–4 hrs / month"
+      - "Data & metadata"
+      - "~1–4 hrs / month"
     excerpt: >-
-      As a triage team member, you'll help keep pyOpenSci's review data accurate and complete — checking that GitHub issues have the right metadata, filling in missing fields like acceptance dates and JOSS DOIs, and ensuring our data pipelines stay healthy. This work directly supports the accuracy of our package listings and what appears on partner sites like the Astropy website. It's a flexible, self-paced role requiring roughly 1–4 hours per month and a great entry point if you want to get involved in the editorial process without a heavy time commitment.
+      As a triage team member, you'll help keep pyOpenSci's review data accurate
+      and complete — checking that GitHub issues have the right metadata,
+      filling in missing fields like acceptance dates and JOSS DOIs, and
+      ensuring our data pipelines stay healthy. This work directly supports the
+      accuracy of our package listings and what appears on partner sites like
+      the Astropy website. It's a flexible, self-paced role requiring roughly
+      1–4 hours per month and a great entry point if you want editorial
+      experience without a heavy time commitment.
     url: "https://forms.gle/XeWcutoLzr54oDv27"
     cta: "Apply to join our triage team"
   - modifier: "card--white"
-    title: "Join our Editor in Chief Team"
+    title: "Join our editor-in-chief team"
     label: "Team role"
     label_style: "team"
     tags:
       - "Leadership"
       - "6–12 month rotation"
     excerpt: >-
-      As an Editor-in-Chief (EiC), you'll be part of a rotating team of 2–4 people who lead the editorial process. EiCs welcome new package submissions on GitHub, evaluate whether a package falls within pyOpenSci's scope, and assign editors to move accepted submissions forward. You'll also field pre-submission inquiries from authors exploring whether their package is a good fit before committing to a full review. This is a hands-on leadership role at the heart of how pyOpenSci maintains quality and community standards. This role typically carries 2-4 hours per week depending on the number of packages that are being submitted.
+      As an Editor-in-Chief (EiC), you'll be part of a rotating team of 2–4
+      people who lead the editorial process. EiCs welcome new package
+      submissions on GitHub, evaluate whether a package falls within pyOpenSci's
+      scope, and assign editors to move accepted submissions forward. You'll
+      also field pre-submission inquiries from authors exploring whether their
+      package is a good fit before committing to a full review. This hands-on
+      leadership role sits at the heart of how pyOpenSci maintains quality and
+      community standards, typically requiring 2–4 hours per week depending on
+      submission volume.
     url: "https://forms.gle/XeWcutoLzr54oDv27"
     cta: "Express interest"
   - modifier: "card--stipend"
-    title: "Become a Peer review lead"
+    title: "Become a peer review lead"
     label: "Stipend"
     label_style: "stipend"
     tags:
       - "Program coordination"
       - "Part-time"
     excerpt: >-
-      As Peer Review Lead, you'll coordinate the entire peer review program — onboarding new editors, working with the Executive Director to update policies, streamline processes, and ensure reviews move forward consistently and efficiently. This is a leadership role at the center of how pyOpenSci's review program runs, typically requiring a few hours per week. Some project management experience is helpful, and the role comes with a stipend every six months in recognition of the commitment it requires.
-    url: "https://forms.gle/XeWcutoLzr54oDv27   "
+      As peer review lead, you'll coordinate the entire peer review program —
+      onboarding new editors, working with the Executive Director to update
+      policies, streamline processes, and ensure reviews move forward
+      consistently and efficiently. This leadership role sits at the center of
+      how pyOpenSci's review program runs, typically requiring a few hours per
+      week. Some project management experience is helpful, and the role comes
+      with a stipend every six months in recognition of the commitment it
+      requires.
+    url: "https://forms.gle/XeWcutoLzr54oDv27"
     cta: "Express interest"
 translation_cards_align: center
 translation_cards:
   - modifier: "card--white"
-    title: "Translation Lead"
+    title: "Translation lead"
     label: "Coordination"
     label_style: "team"
     tags:
@@ -83,10 +113,10 @@ translation_cards:
     excerpt: >-
       Own a language track — coordinate contributors, manage review cycles, and
       keep translations consistent with source updates.
-    url: "mailto:hello@pyopensci.org"
-    cta: "Apply to lead"
+    #url: "mailto:hello@pyopensci.org"
+    #cta: "Apply to lead"
   - modifier: "card--white"
-    title: "Translation Contributor"
+    title: "Translation contributor"
     label: "Async"
     label_style: "accent"
     tags:
@@ -95,8 +125,8 @@ translation_cards:
     excerpt: >-
       Translate or review content for a language you know well. Contribute as
       much or as little as your schedule allows.
-    url: "https://forms.gle/GHfxvmS47nQFDcBM6"
-    cta: "Sign up to translate"
+    #url: "https://forms.gle/GHfxvmS47nQFDcBM6"
+    #cta: "Sign up to translate"
 maintainer_cards_align: left
 maintainer_cards:
   - modifier: "card--white"
@@ -111,7 +141,7 @@ maintainer_cards:
       grow into CI, deployments, and codebase ownership as you get comfortable.
       All skill levels welcome.
     #url: "https://www.pyopensci.org/handbook/CONTRIBUTING.html"
-    #cta: "Become a maintainer →"
+    #cta: "Become a maintainer"
   - modifier: "card--white"
     title: "Website contributor"
     label: "Async"
@@ -183,13 +213,13 @@ of people doing the same.
 
 {{< section-heading eyebrow="Translation" align="left"
     title="Help break down language barriers"
-    subtitle="Our community is global. Our resources should be too. Translation volunteers make pyOpenSci's guides and tutorials accessible to scientists who don't work primarily in English. Translations for our [Python Packaging Guide](https://www.pyopensci.org/python-package-guide/) are in progress. Add a new language or support building out an existing on." />}}
+    subtitle="Our community is global. Our resources should be too. Translation volunteers make pyOpenSci's guides and tutorials accessible to scientists who don't work primarily in English. Translations for our [Python Packaging Guide](https://www.pyopensci.org/python-package-guide/) are in progress — add a new language or help build out an existing translation." />}}
 
 {{< impact-cards section="translation" >}}
 
 {{< /section_band >}}
 
-{{< section-heading eyebrow="pyOpenSci Maintainer Team" align="left"
+{{< section-heading eyebrow="Maintainer team" align="left"
     title="Help build and maintain our infrastructure"
     subtitle="Our maintainer team keeps the website, guides, and tooling running. Roles follow a triage → merge → issue ownership progression. [Read the contributor handbook →](https://www.pyopensci.org/handbook/CONTRIBUTING.html)" />}}
 

--- a/content/volunteer.md
+++ b/content/volunteer.md
@@ -37,7 +37,7 @@ cards:
     excerpt: >-
       As an editor, you'll lead and guide the review process end-to-end — finding and onboarding reviewers who match the package's domain, keeping the review on track, and ensuring reviewers and maintainers meet deadlines. Editors typically lead 2–4 reviews per year, with each active review requiring roughly 1–3 hours per week and quieter periods in between. It's a great opportunity to grow project management skills while supporting open science.
     url: "https://forms.gle/XeWcutoLzr54oDv27"
-    cta: "Apply to be an editor →"
+    cta: "Apply to be an editor"
   - modifier: "card--white"
     title: "Peer review triage"
     label: "Async"
@@ -59,7 +59,7 @@ cards:
     excerpt: >-
       As an Editor-in-Chief (EiC), you'll be part of a rotating team of 2–4 people who lead the editorial process. EiCs welcome new package submissions on GitHub, evaluate whether a package falls within pyOpenSci's scope, and assign editors to move accepted submissions forward. You'll also field pre-submission inquiries from authors exploring whether their package is a good fit before committing to a full review. This is a hands-on leadership role at the heart of how pyOpenSci maintains quality and community standards. This role typically carries 2-4 hours per week depending on the number of packages that are being submitted.
     url: "https://forms.gle/XeWcutoLzr54oDv27"
-    cta: "Express interest →"
+    cta: "Express interest"
   - modifier: "card--stipend"
     title: "Become a Peer review lead"
     label: "Stipend"
@@ -84,7 +84,7 @@ translation_cards:
       Own a language track — coordinate contributors, manage review cycles, and
       keep translations consistent with source updates.
     url: "mailto:hello@pyopensci.org"
-    cta: "Apply to lead →"
+    cta: "Apply to lead"
   - modifier: "card--white"
     title: "Translation Contributor"
     label: "Async"
@@ -96,7 +96,7 @@ translation_cards:
       Translate or review content for a language you know well. Contribute as
       much or as little as your schedule allows.
     url: "https://forms.gle/GHfxvmS47nQFDcBM6"
-    cta: "Sign up to translate →"
+    cta: "Sign up to translate"
 maintainer_cards_align: left
 maintainer_cards:
   - modifier: "card--white"
@@ -123,7 +123,7 @@ maintainer_cards:
       Help keep pyOpenSci.org welcoming and useful — write and edit content,
       improve accessibility, refine our Hugo theme, and polish page layouts.
     #url: "https://github.com/pyOpenSci/pyopensci.github.io"
-    cta: "Support our website →"
+    cta: "Support our website"
 impact_destinations:
   eyebrow: "Your impact"
   title: "Where your work goes"

--- a/content/volunteer.md
+++ b/content/volunteer.md
@@ -207,13 +207,11 @@ of people doing the same.
 {{< impact-cards >}}
 
 
-
-
 {{< section_band color="light-purple" divider="bottom" >}}
 
 {{< section-heading eyebrow="Translation" align="left"
     title="Help break down language barriers"
-    subtitle="Our community is global. Our resources should be too. Translation volunteers make pyOpenSci's guides and tutorials accessible to scientists who don't work primarily in English. Translations for our [Python Packaging Guide](https://www.pyopensci.org/python-package-guide/) are in progress — add a new language or help build out an existing translation." />}}
+    subtitle="Our community is global. Our resources should be too. Translating our education resources to other languages helps make our free online learning content accessible to everyone, everywhere. As a translation volunteer, you will make pyOpenSci's guides and tutorials accessible to scientists who don't work primarily in English. Translation efforts for our [Python Packaging Guide](https://www.pyopensci.org/python-package-guide/) are in progress. Add a new language or help build out an existing translation. Or help us build infrastructure to add translation support to our website. " />}}
 
 {{< impact-cards section="translation" >}}
 
@@ -224,8 +222,6 @@ of people doing the same.
     subtitle="Our maintainer team keeps the website, guides, and tooling running. Roles follow a triage → merge → issue ownership progression. [Read the contributor handbook →](https://www.pyopensci.org/handbook/CONTRIBUTING.html)" />}}
 
 {{< impact-cards section="maintainer" >}}
-
-
 
 
 {{< metrics-bar >}}

--- a/content/volunteer.md
+++ b/content/volunteer.md
@@ -10,44 +10,34 @@ description: >-
 metrics_set: volunteer
 cards_align: center
 cards_layout: five
+cards_padding: compact
 cards:
   - modifier: "card--white"
-    title: "Reviewer"
+    title: "Become a Reviewer"
     label: "Async"
     label_style: "accent"
     tags:
       - "Technical review"
       - "~5–10 hrs / review"
     excerpt: >-
-      Evaluate a Python package for usability, documentation, and packaging
-      best practices. Most reviewers complete one or two reviews per year on
-      their own schedule.
+      As a reviewer, you'll either volunteer when a package request is posted in our Slack
+      or be invited based on your domain expertise or packaging experience. Newer reviewers
+      often focus on domain application and package usability, while experienced reviewers
+      may dig deeper into packaging best practices. Most reviewers complete one or two
+      reviews per year, with each review taking roughly 3–10 hours depending on the package's complexity. Reviewers also receive mentorship from more experienced reviewers to help them through the process.
     url: "https://forms.gle/GHfxvmS47nQFDcBM6"
-    cta: "Sign up to be a reviewer →"
+    cta: "Apply to be a reviewer"
   - modifier: "card--white"
-    title: "Editor"
+    title: "Apply to be an Editor"
     label: "Async"
     label_style: "accent"
     tags:
       - "Editorial oversight"
       - "~3–5 hrs / month"
     excerpt: >-
-      Manage 2–3 active reviews — recruit reviewers, keep submissions on track,
-      and provide light technical guidance.
-    url: "https://docs.google.com/forms/d/e/1FAIpQLScRQHQ7NKVEAG3BKAphiUdVFvQ5nkez0IpyXBMZDzXjuBPloQ/viewform"
+      As an editor, you'll lead and guide the review process end-to-end — finding and onboarding reviewers who match the package's domain, keeping the review on track, and ensuring reviewers and maintainers meet deadlines. Editors typically lead 2–4 reviews per year, with each active review requiring roughly 1–3 hours per week and quieter periods in between. It's a great opportunity to grow project management skills while supporting open science.
+    url: "https://forms.gle/XeWcutoLzr54oDv27"
     cta: "Apply to be an editor →"
-  - modifier: "card--white"
-    title: "Editor in Chief"
-    label: "Team role"
-    label_style: "team"
-    tags:
-      - "Leadership"
-      - "6–12 month rotation"
-    excerpt: >-
-      Serve as rotating lead for the editorial board — onboard new editors,
-      handle escalations, and help shape review policies.
-    #url: "https://docs.google.com/forms/d/e/1FAIpQLScRQHQ7NKVEAG3BKAphiUdVFvQ5nkez0IpyXBMZDzXjuBPloQ/viewform"
-    #cta: "Express interest →"
   - modifier: "card--white"
     title: "Peer review triage"
     label: "Async"
@@ -56,24 +46,31 @@ cards:
       - "Intake & routing"
       - "~2–4 hrs / month"
     excerpt: >-
-      Screen new package submissions before they enter the review queue. A good
-      entry point if you want editorial experience with a lighter time
-      commitment.
-    #url: "https://forms.gle/GHfxvmS47nQFDcBM6"
-    cta: "Sign up for triage →"
+      As a triage team member, you'll help keep pyOpenSci's review data accurate and complete — checking that GitHub issues have the right metadata, filling in missing fields like acceptance dates and JOSS DOIs, and ensuring our data pipelines stay healthy. This work directly supports the accuracy of our package listings and what appears on partner sites like the Astropy website. It's a flexible, self-paced role requiring roughly 1–4 hours per month and a great entry point if you want to get involved in the editorial process without a heavy time commitment.
+    url: "https://forms.gle/XeWcutoLzr54oDv27"
+    cta: "Apply to join our triage team"
+  - modifier: "card--white"
+    title: "Join our Editor in Chief Team"
+    label: "Team role"
+    label_style: "team"
+    tags:
+      - "Leadership"
+      - "6–12 month rotation"
+    excerpt: >-
+      As an Editor-in-Chief (EiC), you'll be part of a rotating team of 2–4 people who lead the editorial process. EiCs welcome new package submissions on GitHub, evaluate whether a package falls within pyOpenSci's scope, and assign editors to move accepted submissions forward. You'll also field pre-submission inquiries from authors exploring whether their package is a good fit before committing to a full review. This is a hands-on leadership role at the heart of how pyOpenSci maintains quality and community standards. This role typically carries 2-4 hours per week depending on the number of packages that are being submitted.
+    url: "https://forms.gle/XeWcutoLzr54oDv27"
+    cta: "Express interest →"
   - modifier: "card--stipend"
-    title: "Peer review lead"
-    label: "Stipended"
+    title: "Become a Peer review lead"
+    label: "Stipend"
     label_style: "stipend"
     tags:
       - "Program coordination"
       - "Part-time"
     excerpt: >-
-      Coordinate the day-to-day health of the review program — track open
-      submissions, support editors, and iterate on process documentation. This
-      role carries a stipend.
-    #url: ""
-    cta: "Apply for this role →"
+      As Peer Review Lead, you'll coordinate the entire peer review program — onboarding new editors, working with the Executive Director to update policies, streamline processes, and ensure reviews move forward consistently and efficiently. This is a leadership role at the center of how pyOpenSci's review program runs, typically requiring a few hours per week. Some project management experience is helpful, and the role comes with a stipend every six months in recognition of the commitment it requires.
+    url: "https://forms.gle/XeWcutoLzr54oDv27   "
+    cta: "Express interest"
 translation_cards_align: center
 translation_cards:
   - modifier: "card--white"
@@ -172,7 +169,10 @@ of people doing the same.
 
 {{< section-heading align="left"
     title="Support software review"
-    subtitle="pyOpenSci runs a community peer review process for research software written in Python. [Learn about peer review →](/about-peer-review/)" >}}
+    subtitle="Help scientists build better, more maintainable software by volunteering in our peer review program." >}}
+* [Learn more about peer review →](/about-peer-review/)
+* [View our detailed guides for more on each role →](https://www.pyopensci.org/software-peer-review/)
+{{< /section-heading >}}
 
 {{< impact-cards >}}
 
@@ -183,7 +183,7 @@ of people doing the same.
 
 {{< section-heading eyebrow="Translation" align="left"
     title="Help break down language barriers"
-    subtitle="Our community is global. Our resources should be too. Translation volunteers make pyOpenSci's guides and tutorials accessible to scientists who don't work primarily in English. Translations for our [Python Packaging Guide](https://www.pyopensci.org/python-package-guide/) are in progress. Add a new language or support building out an existing on." >}}
+    subtitle="Our community is global. Our resources should be too. Translation volunteers make pyOpenSci's guides and tutorials accessible to scientists who don't work primarily in English. Translations for our [Python Packaging Guide](https://www.pyopensci.org/python-package-guide/) are in progress. Add a new language or support building out an existing on." />}}
 
 {{< impact-cards section="translation" >}}
 
@@ -191,7 +191,7 @@ of people doing the same.
 
 {{< section-heading eyebrow="pyOpenSci Maintainer Team" align="left"
     title="Help build and maintain our infrastructure"
-    subtitle="Our maintainer team keeps the website, guides, and tooling running. Roles follow a triage → merge → issue ownership progression. [Read the contributor handbook →](https://www.pyopensci.org/handbook/CONTRIBUTING.html)" >}}
+    subtitle="Our maintainer team keeps the website, guides, and tooling running. Roles follow a triage → merge → issue ownership progression. [Read the contributor handbook →](https://www.pyopensci.org/handbook/CONTRIBUTING.html)" />}}
 
 {{< impact-cards section="maintainer" >}}
 

--- a/themes/clean-hugo/assets/css/_cards.scss
+++ b/themes/clean-hugo/assets/css/_cards.scss
@@ -86,6 +86,11 @@
   }
 }
 
+/* Opt-in: cards_padding: compact — tighter card padding (volunteer role cards) */
+.impact-cards--compact .card {
+  padding: $fluid-card-padding-md;
+}
+
 /* Home-only full-bleed programs section */
 .home-programs-full {
   width: 100vw;
@@ -144,9 +149,9 @@
   }
 
   .card__cta {
-    padding: 0 1.25rem 1.25rem;
+    margin: 0 1.25rem 1.25rem;
     @media (min-width: $breakpoint-md) {
-      padding: 0 2.5rem 2.5rem;
+      margin: 0 2.5rem 2.5rem;
     }
   }
 
@@ -384,14 +389,13 @@
   }
 
   .card__cta {
-    margin-top: 1rem;
-    @include responsive(font-size, 0.875rem, 1rem);
-    color: var(--color-link);
-    transition: color $transition-base ease;
+    margin-top: auto;
+    align-self: flex-start;
 
-    &:hover,
-    &:focus {
-      color: var(--color-link-hover);
+    &.btn {
+      padding: 0.625rem 1.25rem;
+      font-size: 1rem;
+      background-color: var(--color-white);
     }
   }
 

--- a/themes/clean-hugo/assets/css/_shortcodes.scss
+++ b/themes/clean-hugo/assets/css/_shortcodes.scss
@@ -288,10 +288,45 @@
     }
   }
 
+  .section-heading__links {
+    margin-top: 0.75rem;
+    text-align: center;
+    @include responsive(font-size, 1.125rem, 1.25rem);
+    color: var(--color-gray-600);
+
+    ul {
+      margin: 0;
+      padding-left: 1.25rem;
+      list-style: disc;
+    }
+
+    li {
+      margin-bottom: 0.35rem;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    a {
+      color: var(--color-link);
+
+      &:hover,
+      &:focus {
+        color: var(--color-link-hover);
+      }
+    }
+  }
+
   .section-heading--left {
     text-align: left;
 
     .section-heading__subtitle {
+      text-align: left;
+      max-width: 42rem;
+    }
+
+    .section-heading__links {
       text-align: left;
       max-width: 42rem;
     }

--- a/themes/clean-hugo/layouts/partials/card-cta.html
+++ b/themes/clean-hugo/layouts/partials/card-cta.html
@@ -1,4 +1,0 @@
-{{/* Card CTA — white outline button with Font Awesome arrow */}}
-{{ $ctaRaw := .cta | default "Learn more →" }}
-{{ $ctaLabel := trim (replaceRE " *→$" "" $ctaRaw) " " }}
-<a class="btn btn--outline btn--icon card__cta" href="{{ .url }}">{{ $ctaLabel }}<i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>

--- a/themes/clean-hugo/layouts/partials/card-cta.html
+++ b/themes/clean-hugo/layouts/partials/card-cta.html
@@ -1,0 +1,4 @@
+{{/* Card CTA — white outline button with Font Awesome arrow */}}
+{{ $ctaRaw := .cta | default "Learn more →" }}
+{{ $ctaLabel := trim (replaceRE " *→$" "" $ctaRaw) " " }}
+<a class="btn btn--outline btn--icon card__cta" href="{{ .url }}">{{ $ctaLabel }}<i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>

--- a/themes/clean-hugo/layouts/partials/cards.html
+++ b/themes/clean-hugo/layouts/partials/cards.html
@@ -31,7 +31,7 @@
       {{ end }}
       {{ with .url }}
         <div>
-          {{ partial "card-cta.html" (dict "url" . "cta" $.cta) }}
+          <a class="btn btn--outline btn--icon card__cta" href="{{ . }}">{{ $.cta | default "Learn more" }}<i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
         </div>
       {{ end }}
     </div>
@@ -76,7 +76,7 @@
   </div>
 
   {{ with .url }}
-    {{ partial "card-cta.html" (dict "url" . "cta" $.cta) }}
+    <a class="btn btn--outline btn--icon card__cta" href="{{ . }}">{{ $.cta | default "Learn more" }}<i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
   {{ end }}
 </article>
 {{ end }}

--- a/themes/clean-hugo/layouts/partials/cards.html
+++ b/themes/clean-hugo/layouts/partials/cards.html
@@ -31,7 +31,7 @@
       {{ end }}
       {{ with .url }}
         <div>
-          <a class="card__cta" href="{{ . }}">{{ $.cta | default "Learn more →" }}</a>
+          {{ partial "card-cta.html" (dict "url" . "cta" $.cta) }}
         </div>
       {{ end }}
     </div>
@@ -76,7 +76,7 @@
   </div>
 
   {{ with .url }}
-    <a class="card__cta" href="{{ . }}">{{ $.cta | default "Learn more →" }}</a>
+    {{ partial "card-cta.html" (dict "url" . "cta" $.cta) }}
   {{ end }}
 </article>
 {{ end }}

--- a/themes/clean-hugo/layouts/partials/impact-cards.html
+++ b/themes/clean-hugo/layouts/partials/impact-cards.html
@@ -2,6 +2,7 @@
  Content grabbed from yaml front matter.
  Optional section param: reads {section}_cards (e.g. translation_cards).
  Optional: cards_layout / {section}_cards_layout: wide.
+ Optional: cards_padding / {section}_cards_padding: compact.
  Optional: cards_align / {section}_cards_align: left | center | right (default: center).
  Shortcode align param overrides page alignment. -->
 
@@ -17,10 +18,12 @@
 {{ $cardsKey := "cards" }}
 {{ $alignKey := "cards_align" }}
 {{ $layoutKey := "cards_layout" }}
+{{ $paddingKey := "cards_padding" }}
 {{ if ne $section "" }}
   {{ $cardsKey = printf "%s_cards" $section }}
   {{ $alignKey = printf "%s_cards_align" $section }}
   {{ $layoutKey = printf "%s_cards_layout" $section }}
+  {{ $paddingKey = printf "%s_cards_padding" $section }}
 {{ end }}
 
 {{ if eq $align "" }}
@@ -40,8 +43,17 @@
 {{ $layoutLower := lower $layout }}
 {{ $wide := eq $layoutLower "wide" }}
 {{ $five := eq $layoutLower "five" }}
+
+{{ $padding := "" }}
+{{ if ne $section "" }}
+  {{ $padding = index $page.Params $paddingKey | default "" }}
+{{ else }}
+  {{ $padding = index $page.Params "cards_padding" | default "" }}
+{{ end }}
+{{ $compact := eq (lower $padding) "compact" }}
+
 <section
-  class="impact-cards impact-cards--align-{{ $align }}{{ if $wide }} impact-cards--wide{{ end }}{{ if $five }} impact-cards--five{{ end }}">
+  class="impact-cards impact-cards--align-{{ $align }}{{ if $wide }} impact-cards--wide{{ end }}{{ if $five }} impact-cards--five{{ end }}{{ if $compact }} impact-cards--compact{{ end }}">
   <div class="impact-cards__container">
     <div class="impact-cards__grid{{ if $wide }} impact-cards__grid--wide{{ end }}{{ if $five }} impact-cards__grid--five{{ end }}">
       {{ $cards := index $page.Params $cardsKey }}

--- a/themes/clean-hugo/layouts/shortcodes/section-heading.html
+++ b/themes/clean-hugo/layouts/shortcodes/section-heading.html
@@ -13,4 +13,8 @@
   {{ if $subtitle }}
   <div class="section-heading__subtitle">{{ $subtitle | markdownify }}</div>
   {{ end }}
+  {{ $links := trim .Inner " \n\r\t" }}
+  {{ if $links }}
+  <div class="section-heading__links">{{ $links | markdownify }}</div>
+  {{ end }}
 </div>


### PR DESCRIPTION
I combined our forms so now we have a single application process for editor, eic, triage, and peer review lead. 

i then added more context for each position so the roles were clear