### PR TITLE
Update SciPy 2024 keynote speaker link - Barnes

### DIFF
--- a/content/blog/2024-05-28-pyos-newsletter-june-2024.md
+++ b/content/blog/2024-05-28-pyos-newsletter-june-2024.md
@@ -126,7 +126,7 @@ If you're interested in joining our Editorial Board, but have questions or would
 
 ## <i class="fa-brands fa-python"></i> Upcoming Python events for scientists
 ### SciPy
-With keynotes from [Julia Silge](https://juliasilge.com/), [Dr. Elizabeth (Libby) Barnes](https://sites.google.com/view/barnesgroup-csu/prof-barnes), and [Kyle Cranmer](https://www.physics.wisc.edu/directory/cranmer-kyle/), [SciPy 2024](https://www.scipy2024.scipy.org/) is going to be yet another conference you don't want to miss! Held at the Tacoma Convention Center, July 8-14, 2024, [tickets are still available](https://ti.to/scipy/scipy2024)!
+With keynotes from [Julia Silge](https://juliasilge.com/), [Dr. Elizabeth (Libby) Barnes](https://barnes-research.com/prof-barnes/), and [Kyle Cranmer](https://www.physics.wisc.edu/directory/cranmer-kyle/), [SciPy 2024](https://www.scipy2024.scipy.org/) is going to be yet another conference you don't want to miss! Held at the Tacoma Convention Center, July 8-14, 2024, [tickets are still available](https://ti.to/scipy/scipy2024)!
 
 ### PyData Eindhoven
 With 14 captivating talks lined up, [PyData Eindhoven](https://pydata.org/eindhoven2024/)  offers a diverse range of topics to expand your knowledge and inspire innovative thinking. From cutting-edge data analysis techniques to machine learning applications, our expert speakers will cover it all. Co-hosted with Day 2 of [JuliaCon](https://juliacon.org/2024/), [grab your tickets](https://pydata.org/eindhoven2024/) and join your peers in the Netherlands this July 11th!


### PR DESCRIPTION
The previous link is 404. Updated to valid link