### PR TITLE
feat: add header links and keep reading to blog post pages

### DIFF
--- a/themes/clean-hugo/assets/css/_blog.scss
+++ b/themes/clean-hugo/assets/css/_blog.scss
@@ -260,6 +260,19 @@
   }
 }
 
+/* "Keep reading" related posts, shown after post content.
+   Reuses .blog-highlight / .highlight-grid / .listing-card--on-dark
+   as-is (see _cards.scss); this just adds the full-bleed breakout
+   since this section sits outside .content-main / .splash-page__content,
+   where that breakout is already defined (see _content.scss). */
+.blog-post__keep-reading.blog-highlight {
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  margin-inline: -50vw;
+
+}
+
 /* Optional in-page TOC (toc: true in front matter) */
 $blog-toc-width: 14rem;
 $blog-toc-gap: 2rem;
@@ -357,14 +370,13 @@ $blog-toc-gap: 2rem;
 
   .highlight-grid {
     max-width: $container-wide;
-    margin: 2.5rem auto 0;
+    margin: 2rem auto 0;
     gap: 4rem 2rem;
-    border-top: 1px solid var(--color-gray-700);
     padding-top: 2.5rem;
 
     @media (min-width: $breakpoint-sm) {
-      margin-top: 4rem;
-      padding-top: 4rem;
+      margin-top: 2rem;
+      padding-top: 2rem;
     }
 
     @media (min-width: $breakpoint-lg) {

--- a/themes/clean-hugo/assets/css/_heading-anchor.scss
+++ b/themes/clean-hugo/assets/css/_heading-anchor.scss
@@ -24,11 +24,11 @@
 
   &:hover,
   &:focus-visible {
-    color: var(--color-primary);
+    color: var(--color-link-on-dark);
   }
 
   &:focus-visible {
-    outline: 2px solid var(--color-primary);
+    outline: 2px solid var(--color-link-on-dark);
     outline-offset: 2px;
     border-radius: $radius-sm;
   }

--- a/themes/clean-hugo/assets/css/_heading-anchor.scss
+++ b/themes/clean-hugo/assets/css/_heading-anchor.scss
@@ -1,0 +1,78 @@
+/*
+  Heading anchor links
+  The render hook (layouts/_default/_markup/render-heading.html)
+  adds a small link icon after every H2-H4 in Markdown content.
+  It stays hidden until the heading is hovered/focused, and
+  clicking it copies the section URL to the clipboard.
+*/
+.heading-anchor {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1em;
+  height: 1em;
+  margin-left: $spacing-xs;
+  vertical-align: middle;
+  color: var(--color-gray-600);
+  opacity: 0;
+  text-decoration: none;
+  transition: opacity $transition-fast ease, color $transition-fast ease;
+
+  .fa-link {
+    font-size: 0.7em;
+  }
+
+  &:hover,
+  &:focus-visible {
+    color: var(--color-primary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: $radius-sm;
+  }
+}
+
+h2:hover,
+h3:hover,
+h4:hover {
+  .heading-anchor {
+    opacity: 1;
+  }
+}
+
+.heading-anchor:focus-visible {
+  opacity: 1;
+}
+
+/* Brief "Link copied" tooltip shown after a click */
+.heading-anchor--copied {
+  opacity: 1;
+  position: relative;
+
+  &::after {
+    content: 'Link copied';
+    position: absolute;
+    bottom: calc(100% + 0.4rem);
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: var(--color-gray-900);
+    color: var(--color-white);
+    font-family: $font-family-body;
+    font-size: 0.75rem;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+    padding: 0.25rem 0.5rem;
+    border-radius: $radius-sm;
+    pointer-events: none;
+  }
+}
+
+/* No hover on touch devices, so keep the icon visible there */
+@media (hover: none) {
+  .heading-anchor {
+    opacity: 1;
+  }
+}

--- a/themes/clean-hugo/assets/css/main.scss
+++ b/themes/clean-hugo/assets/css/main.scss
@@ -287,6 +287,7 @@ xl: 1280px
 @import 'navigation';
 @import 'search';
 @import 'content';
+@import 'heading-anchor';
 @import 'blog';
 @import 'learn-more';
 @import 'filter';

--- a/themes/clean-hugo/layouts/_default/_markup/render-heading.html
+++ b/themes/clean-hugo/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,17 @@
+{{- /*
+  Render hook for Markdown headings (site-wide).
+  Adds a hidden-until-hover "copy link" icon after H2-H4 text so
+  any section can be linked to directly, similar to Minimal
+  Mistakes' anchor links. H1 is left untouched since it's the
+  page title, not a linkable section.
+*/ -}}
+{{- $level := .Level -}}
+{{- $showAnchor := and (ge $level 2) (le $level 4) -}}
+<h{{ $level }} id="{{ .Anchor }}"{{ range $name, $value := .Attributes }}{{ if ne $name "id" }} {{ $name }}="{{ $value }}"{{ end }}{{ end }}>
+  {{- .Text | safeHTML }}
+  {{- if $showAnchor }}
+  <a href="#{{ .Anchor }}" class="heading-anchor" data-heading-anchor aria-label="Copy link to {{ .PlainText }} section">
+    <i class="fas fa-link" aria-hidden="true"></i>
+  </a>
+  {{- end }}
+</h{{ $level }}>

--- a/themes/clean-hugo/layouts/_default/baseof.html
+++ b/themes/clean-hugo/layouts/_default/baseof.html
@@ -218,6 +218,8 @@
 
   {{/* Navigation bar toggle JavaScript */}}
   <script src="{{ "js/navigation.js" | relURL }}" defer></script>
+  {{/* Copy-link behavior for the H2-H4 heading anchor icons */}}
+  <script src="{{ "js/heading-anchors.js" | relURL }}" defer></script>
   {{ if .Site.Params.search.enable }}
     <script src="{{ "js/algolia-search.js" | relURL }}" defer></script>
     <script src="{{ "js/search.js" | relURL }}" defer></script>

--- a/themes/clean-hugo/layouts/blog/single.html
+++ b/themes/clean-hugo/layouts/blog/single.html
@@ -34,6 +34,8 @@
       {{ partial "last-modified.html" . }}
     </article>
   </div>
+
+  {{ partial "blog-keep-reading.html" . }}
   {{ else }}
   {{ with .Params.excerpt }}
   <div class="blog-post__excerpt">
@@ -55,6 +57,8 @@
     <!-- Last modified date -->
     {{ partial "last-modified.html" . }}
   </article>
+
+  {{ partial "blog-keep-reading.html" . }}
   {{ end }}
 
 {{ if and .Params.toc site.Params.blog.enable_toc }}

--- a/themes/clean-hugo/layouts/partials/blog-keep-reading.html
+++ b/themes/clean-hugo/layouts/partials/blog-keep-reading.html
@@ -1,0 +1,86 @@
+{{/*
+  "Keep reading" related posts, shown at the end of a blog post.
+  Reuses the same dark "blog-highlight" section and "listing-card
+  listing-card--on-dark" card markup as the home page recent-posts
+  block (see shortcodes/blog-list.html), so styling stays consistent
+  site-wide.
+
+  Selection:
+  1. Posts sharing the current post's blog_topic (data/blog_topics.yml),
+     most recent first.
+  2. If fewer than 3 match, backfill with the most recent remaining
+     posts site-wide until there are 3 (or fewer, if the site doesn't
+     have that many posts).
+
+  Parameters:
+  - "." (context): The current blog post page object
+*/}}
+{{ $page := . }}
+{{ $topic := partial "blog-topic.html" $page }}
+{{ $topicSlug := $topic.slug }}
+
+{{ $allPosts := where site.RegularPages "Type" "blog" }}
+{{ $others := where $allPosts "RelPermalink" "ne" $page.RelPermalink }}
+{{ $others = sort $others "Date" "desc" }}
+
+{{ $related := slice }}
+{{ $usedLinks := slice }}
+
+{{ range $others }}
+  {{ if lt (len $related) 3 }}
+    {{ $otherTopic := partial "blog-topic.html" . }}
+    {{ if eq $otherTopic.slug $topicSlug }}
+      {{ $related = $related | append . }}
+      {{ $usedLinks = $usedLinks | append .RelPermalink }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ if lt (len $related) 3 }}
+  {{ range $others }}
+    {{ if lt (len $related) 3 }}
+      {{ if not (in $usedLinks .RelPermalink) }}
+        {{ $related = $related | append . }}
+        {{ $usedLinks = $usedLinks | append .RelPermalink }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ if gt (len $related) 0 }}
+<section class="blog-post__keep-reading blog-highlight">
+  <div class="container">
+    <div class="intro">
+      <h2>Keep reading</h2>
+    </div>
+
+    <div class="highlight-grid">
+      {{ range $related }}
+        {{ $relatedTopic := partial "blog-topic.html" . }}
+        <article class="listing-card listing-card--on-dark listing-card--density-default">
+          <div class="meta">
+            <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
+            {{ with $relatedTopic.label }}
+              <span class="category">{{ . }}</span>
+            {{ end }}
+          </div>
+
+          <div class="content">
+            <h3>
+              <a href="{{ .Permalink }}">{{ .Title }}</a>
+            </h3>
+
+            <p class="excerpt">
+              {{ partial "blog-excerpt.html" (dict "." . "length" 200) }}
+            </p>
+
+            <a href="{{ .Permalink }}" class="read-more">
+              Read more <i class="fas fa-arrow-right"></i>
+            </a>
+          </div>
+        </article>
+      {{ end }}
+    </div>
+  </div>
+</section>
+{{ end }}

--- a/themes/clean-hugo/static/js/heading-anchors.js
+++ b/themes/clean-hugo/static/js/heading-anchors.js
@@ -1,0 +1,30 @@
+/**
+ * Heading anchor links.
+ * Each H2-H4 gets a "copy link" icon (added by the
+ * render-heading.html hook). Clicking it copies the section's
+ * full URL to the clipboard and shows a brief "Link copied"
+ * tooltip. The icon is still a real `href="#id"` link, so it
+ * keeps working (jump + right-click "copy link") with JS off.
+ */
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('[data-heading-anchor]').forEach(function (anchor) {
+    anchor.addEventListener('click', function (event) {
+      event.preventDefault();
+
+      const hash = anchor.getAttribute('href');
+      const url = window.location.origin + window.location.pathname + hash;
+
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(url).catch(function () {});
+      }
+
+      history.pushState(null, '', hash);
+
+      anchor.classList.add('heading-anchor--copied');
+      clearTimeout(anchor._copyTimeout);
+      anchor._copyTimeout = setTimeout(function () {
+        anchor.classList.remove('heading-anchor--copied');
+      }, 1500);
+    });
+  });
+});


### PR DESCRIPTION
This adds 2 new features

1. it adds the header links that minimal mistakes theme had to h2-h4 for easier sublinking throughout the site
2. It adds a "keep reading" section at the bottom of each blog post reusing the highlighted blogs partial from the home page. 