### PR TITLE
Fix: editorial team data should drive sorting editorial team list

### DIFF
--- a/data/editorial-board.yml
+++ b/data/editorial-board.yml
@@ -10,7 +10,7 @@ coatless:
   emeritus_eic: false
 crhea93:
   peer_review_lead: false
-  eic_team: false
+  eic_team: true
   emeritus_peer_review_lead: false
   emeritus_eic: false
 ctb:

--- a/themes/clean-hugo/layouts/partials/people/active-editorial-grid.html
+++ b/themes/clean-hugo/layouts/partials/people/active-editorial-grid.html
@@ -9,24 +9,21 @@
   {{ $contrib := partial "people/lookup-contributor.html" (dict
     "username" $username
     "contributors" $contributors) }}
-  {{ $tier := 2 }}
+  {{/* Grid order: PR lead, EiC, triage, then editors */}}
+  {{ $tier := 3 }}
   {{ if $roles.peer_review_lead }}
     {{ $tier = 0 }}
-  {{ else if $roles.eic_team }}
+  {{ else if or $roles.eic $roles.eic_team }}
     {{ $tier = 1 }}
-  {{ end }}
-  {{ $sort := 99 }}
-  {{ with $contrib }}
-    {{ $sort = .sort | default 99 }}
+  {{ else if $roles.triage }}
+    {{ $tier = 2 }}
   {{ end }}
   {{ $entries = $entries | append (dict
     "username" $username
     "contrib" $contrib
     "roles" $roles
-    "tier" $tier
-    "sort" $sort) }}
+    "tier" $tier) }}
 {{ end }}
-{{ $entries = sort $entries "sort" "asc" }}
 {{ $entries = sort $entries "tier" "asc" }}
 <div class="people-grid-static">
   {{ range $entries }}

--- a/themes/clean-hugo/layouts/partials/people/editorial-role-title.html
+++ b/themes/clean-hugo/layouts/partials/people/editorial-role-title.html
@@ -1,29 +1,47 @@
 {{/*
-  Single primary title from editorial-board / emeritus-editors role flags.
+  Titles from editorial-board / emeritus-editors role flags.
   Usage:
     {{ partial "people/editorial-role-title.html" (dict
       "roles" $roles
       "board" "active") }}
   board: "active" | "emeritus"
 
-  Active precedence (phase 1): peer_review_lead > eic_team > Editor.
-  Historical emeritus_* flags are ignored for active card labels.
+  Active title order (specialties first, base last):
+  Peer Review Lead, Editor in Chief, Peer Review Triage,
+  then historical emeritus_*, then Editor.
+  Reads eic / triage; falls back to legacy eic_team until data
+  is regenerated.
+  Emeritus branch exists but emeritus pills do not render titles.
 */}}
 {{ $roles := .roles }}
 {{ $titles := slice }}
 {{ if eq .board "active" }}
   {{ if $roles.peer_review_lead }}
     {{ $titles = $titles | append "Peer Review Lead" }}
-  {{ else if $roles.eic_team }}
-    {{ $titles = $titles | append "Editor in Chief" }}
-  {{ else }}
-    {{ $titles = $titles | append "Editor" }}
   {{ end }}
+  {{ if or $roles.eic $roles.eic_team }}
+    {{ $titles = $titles | append "Editor in Chief" }}
+  {{ end }}
+  {{ if $roles.triage }}
+    {{ $titles = $titles | append "Peer Review Triage" }}
+  {{ end }}
+  {{ if $roles.emeritus_peer_review_lead }}
+    {{ $titles = $titles | append "Emeritus Peer Review Lead" }}
+  {{ end }}
+  {{ if $roles.emeritus_eic }}
+    {{ $titles = $titles | append "Emeritus Editor in Chief" }}
+  {{ end }}
+  {{ if $roles.emeritus_triage }}
+    {{ $titles = $titles | append "Emeritus Peer Review Triage" }}
+  {{ end }}
+  {{ $titles = $titles | append "Editor" }}
 {{ else }}
   {{ if $roles.emeritus_peer_review_lead }}
     {{ $titles = $titles | append "Emeritus Peer Review Lead" }}
   {{ else if $roles.emeritus_eic }}
     {{ $titles = $titles | append "Emeritus Editor in Chief" }}
+  {{ else if $roles.emeritus_triage }}
+    {{ $titles = $titles | append "Emeritus Peer Review Triage" }}
   {{ else }}
     {{ $titles = $titles | append "Emeritus Editor" }}
   {{ end }}

--- a/themes/clean-hugo/layouts/partials/people/editorial-role-title.html
+++ b/themes/clean-hugo/layouts/partials/people/editorial-role-title.html
@@ -1,37 +1,30 @@
 {{/*
-  Build display title(s) from editorial-board / emeritus-editors role flags.
+  Single primary title from editorial-board / emeritus-editors role flags.
   Usage:
     {{ partial "people/editorial-role-title.html" (dict
       "roles" $roles
       "board" "active") }}
   board: "active" | "emeritus"
+
+  Active precedence (phase 1): peer_review_lead > eic_team > Editor.
+  Historical emeritus_* flags are ignored for active card labels.
 */}}
 {{ $roles := .roles }}
 {{ $titles := slice }}
 {{ if eq .board "active" }}
   {{ if $roles.peer_review_lead }}
     {{ $titles = $titles | append "Peer Review Lead" }}
-  {{ end }}
-  {{ if $roles.eic_team }}
+  {{ else if $roles.eic_team }}
     {{ $titles = $titles | append "Editor in Chief" }}
-  {{ end }}
-  {{ if $roles.emeritus_peer_review_lead }}
-    {{ $titles = $titles | append "Emeritus Peer Review Lead" }}
-  {{ end }}
-  {{ if $roles.emeritus_eic }}
-    {{ $titles = $titles | append "Emeritus Editor in Chief" }}
-  {{ end }}
-  {{ if eq (len $titles) 0 }}
+  {{ else }}
     {{ $titles = $titles | append "Editor" }}
   {{ end }}
 {{ else }}
   {{ if $roles.emeritus_peer_review_lead }}
     {{ $titles = $titles | append "Emeritus Peer Review Lead" }}
-  {{ end }}
-  {{ if $roles.emeritus_eic }}
+  {{ else if $roles.emeritus_eic }}
     {{ $titles = $titles | append "Emeritus Editor in Chief" }}
-  {{ end }}
-  {{ if eq (len $titles) 0 }}
+  {{ else }}
     {{ $titles = $titles | append "Emeritus Editor" }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
This is a small set of fixes to ensure people are sorted on the team by title and that all titles come from the new editorial team yml file. 