### PR TITLE
fix: update action to run editorial updates

### DIFF
--- a/.github/workflows/update-contribs-reviews.yml
+++ b/.github/workflows/update-contribs-reviews.yml
@@ -43,6 +43,8 @@ jobs:
           add-paths: |
             data/contributors.yml
             data/packages.yml
+            data/editorial-board.yml
+            data/emeritus-editors.yml
           author: Leah <leah@pyopensci.org>
           base: main
           branch: contribs

--- a/.github/workflows/update-contribs-reviews.yml
+++ b/.github/workflows/update-contribs-reviews.yml
@@ -30,6 +30,13 @@ jobs:
           update-review-teams
           mkdir -p data
 
+      - name: Update editorial board
+        env:
+          # Using a fine grained token here that only has team read access.
+          GITHUB_TOKEN_TEAMS: ${{ secrets.PYOS_READ_TEAM_MEMBERS_SECRET }}
+        run: |
+          update-editorial-board
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:


### PR DESCRIPTION
Ok this is working over in pyosmeta as an end to end test in ci. so hopefully it works the same here. The goal here is that we can pull down a list of current and emeritus editors and update the website automatically as long as we remember to onboard and offboard them from the proper github teams.