### PR TITLE
fix: add a few editors manually

### DIFF
--- a/data/manual-editorial-roster.yml
+++ b/data/manual-editorial-roster.yml
@@ -1,0 +1,23 @@
+# Hand-maintained editorial roster overrides.
+# People who cannot / will not be on GitHub org teams.
+# Merged by update-editorial-board after team fetch. Do not overwrite
+# this file from CI.
+#
+# editor: true          → editorial-board.yml (active editor)
+# emeritus_editor: true → emeritus-editors.yml
+# Specialty flags optional (eic, triage, emeritus_eic, …).
+
+jbencook:
+  name: Ben Cook
+  note: "Not on GitHub teams; keep as emeritus editor"
+  emeritus_editor: true
+
+dhomeier:
+  name: Derek Homeier
+  note: "Not on GitHub teams; keep as active editor"
+  editor: true
+
+russbiggs:
+  name: Russ Biggs
+  note: "Not on GitHub teams; keep as emeritus editor"
+  emeritus_editor: true


### PR DESCRIPTION
This adds just a few editors manually who aren't in our org and never accepted the invitation. it allows us to sync them to our teams and allows for us in the future (once i update pyosmeta) to update that file manually in case someone else can't join our org but wants to be listed on the website