### PR TITLE
feat: show accepted date on package cards

### DIFF
--- a/themes/clean-hugo/assets/css/_packages.scss
+++ b/themes/clean-hugo/assets/css/_packages.scss
@@ -175,6 +175,14 @@
           line-height: 1.6rem;
           margin-bottom: 0;
 
+          &.package_card__date-accepted {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            color: var(--color-gray-600);
+            font-size: 0.875rem;
+          }
+
           &.package_card__archived {
             display: inline-flex;
             align-items: center;

--- a/themes/clean-hugo/layouts/partials/packages/card-static.html
+++ b/themes/clean-hugo/layouts/partials/packages/card-static.html
@@ -15,19 +15,40 @@
     <p>{{ .package_description }}</p>
 
     <ul>
+      {{ if and .date_accepted (ne .date_accepted "missing") }}
+        <li class="package_card__date-accepted">
+          <i class="fas fa-calendar-check" aria-hidden="true"></i>
+          Accepted: {{ .date_accepted }}
+        </li>
+      {{ end }}
+
       {{ with .repository_link }}
-        <li><a href="{{ . }}" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i> View Code</a></li>
+        <li>
+          <a href="{{ . }}" target="_blank" rel="noopener noreferrer">
+            <i class="fab fa-github"></i> View Code
+          </a>
+        </li>
       {{ end }}
 
       {{ if .active }}
         {{ with .gh_meta }}
           {{ with .documentation }}
-            <li><a href="{{ . }}" target="_blank" rel="noopener noreferrer"><i class="fas fa-book-open"></i> View Docs</a></li>
+            <li>
+              <a href="{{ . }}" target="_blank" rel="noopener noreferrer">
+                <i class="fas fa-book-open"></i> View Docs
+              </a>
+            </li>
           {{ end }}
         {{ end }}
+
         {{ with .issue_link }}
-          <li><a href="{{ . }}" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-user-pen"></i> View Review</a></li>
+          <li>
+            <a href="{{ . }}" target="_blank" rel="noopener noreferrer">
+              <i class="fa-solid fa-user-pen"></i> View Review
+            </a>
+          </li>
         {{ end }}
+
         {{ partial "packages/citation-link.html" . }}
       {{ else }}
         <li class="package_card__archived">

--- a/themes/clean-hugo/layouts/partials/packages/grid.html
+++ b/themes/clean-hugo/layouts/partials/packages/grid.html
@@ -86,6 +86,14 @@
             </li>
           </template>
 
+          {{/* Accepted date */}}
+          <template x-if="pkg.date_accepted && pkg.date_accepted !== 'missing'">
+            <li class="package_card__date-accepted">
+              <i class="fas fa-calendar-check" aria-hidden="true"></i>
+              <span x-text="'Accepted: ' + pkg.date_accepted"></span>
+            </li>
+          </template>
+
           {{/* Archived badge for archived packages */}}
           <template x-if="pkg.active === false">
             <li class="package_card__archived">


### PR DESCRIPTION
This PR follows up on #805.
Now that `date_accepted` is populated for all packages, it adds the accepted date to package cards in the Alpine-rendered grid and the static Hugo card partial.

**Changes**
- Show `date_accepted` on package cards
- Keep the Alpine and static card implementations consistent
- Add styling for the accepted-date metadata
- Skip rendering when the value is missing

**Testing**
Tested locally with the Hugo development server and confirmed that package cards render correctly in _index.md and python-packages.md (refer to the attached screenshots).

<img width="1312" height="656" alt="pyos-packcards" src="https://github.com/user-attachments/assets/f517ad92-68aa-46c1-b575-658497b14c33" />
<img width="1429" height="580" alt="pyos-packcards2" src="https://github.com/user-attachments/assets/be0c3c11-fe82-454b-9916-b4e6610db928" />